### PR TITLE
AN-428: Generate Python client code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ TAGS
 dist/
 dist-newstyle/
 cabal-dev/
+/venv*/
 *.o
 *.hi
 *.chi

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 TAGS
-dist
-cabal-dev
+dist/
+dist-newstyle/
+cabal-dev/
 *.o
 *.hi
 *.chi

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,16 @@
+TODO
+====
+
+- Dependency computation seems to be fragile.
+    - When two modules contain a declaration with the same name, the latter will
+      depend on the former. No dependency should be added.
+    - When declarations exist with the same name, sometimes a dependency will be
+      added with the module name concatenated with itself.
+
+- Python classes with no fields have too much white space.
+
+- Python variants need de-/serialisation functionality in the base class.
+
+- Python docstring generation is a bit flaky.
+
+- Dependency information should be used to generate precise imports.

--- a/TODO.md
+++ b/TODO.md
@@ -6,11 +6,3 @@ TODO
       depend on the former. No dependency should be added.
     - When declarations exist with the same name, sometimes a dependency will be
       added with the module name concatenated with itself.
-
-- Python classes with no fields have too much white space.
-
-- Python variants need de-/serialisation functionality in the base class.
-
-- Python docstring generation is a bit flaky.
-
-- Dependency information should be used to generate precise imports.

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,6 @@
 packages: machinator-core/
           machinator-haskell/
+          machinator-python/
           machinator-scala/
           machinator-swagger/
           lib/disorder/disorder-aeson

--- a/example/aggregate.mcn
+++ b/example/aggregate.mcn
@@ -1,5 +1,7 @@
 -- machinator @ v2
+{-- A file -}
 
+{- | Aggregations to apply to query results. -}
 data AggregateExpression
-  = Sum {}
-  | Average {}
+  = Sum
+  | Average

--- a/example/aggregate.mcn
+++ b/example/aggregate.mcn
@@ -1,6 +1,12 @@
 -- machinator @ v2
 {-- A file -}
 
+{- | Another example. -}
+data Size
+  = Large
+  | Medium
+  | Small
+
 {- | Aggregations to apply to query results. -}
 data AggregateExpression
   = Sum

--- a/example/feature.mcn
+++ b/example/feature.mcn
@@ -4,6 +4,7 @@
 {- | Unique identifiers for features. -}
 newtype FeatureId = { value: Int }
 
+{- | Unique identified for feature versions. -}
 newtype FeatureVersionId = { value: UUID }
 
 {- | SQL-safe names for features. -}
@@ -21,19 +22,20 @@ data QualityRating
    | Silver
    | Bronze
 
-
 {- | Unique identifiers for entities. -}
 newtype EntityId = { value: Int }
 
 {- | Unique identifier for templates. -}
 newtype TemplateId = { value: Int }
 
+{- | Unique identifier for tables. -}
 newtype TableId = { value: Int }
 
 
-{- | What is this -}
+{- | Feature definitions. -}
 data Feature
- = EventFeature {
+ = {- | Definition of an event feature. -}
+   EventFeature {
     id: FeatureId,
     name: FeatureName,
     description: String,
@@ -49,7 +51,8 @@ data Feature
     template: Maybe TemplateId,
     version: FeatureVersionId
    }
-  | RowFeature {
+  | {- | Definition of a row feature. -}
+   RowFeature {
      id: FeatureId,
      name: FeatureName,
      description: String,

--- a/example/feature.mcn
+++ b/example/feature.mcn
@@ -1,5 +1,6 @@
 -- machinator @ v2
 
+{- | What is this -}
 data Feature
  = EventFeature {
     id: FeatureId,

--- a/example/feature.mcn
+++ b/example/feature.mcn
@@ -1,5 +1,36 @@
 -- machinator @ v2
 
+
+{- | Unique identifiers for features. -}
+newtype FeatureId = { value: Int }
+
+newtype FeatureVersionId = { value: UUID }
+
+{- | SQL-safe names for features. -}
+newtype FeatureName = { value: String }
+
+{- | Metadata label. -}
+newtype Label = { value: String }
+
+{- | Metadata key/value pair. -}
+record Attribute = { key: String, value: Maybe String }
+
+{- | Quality metadata for features. -}
+data QualityRating
+   = Gold
+   | Silver
+   | Bronze
+
+
+{- | Unique identifiers for entities. -}
+newtype EntityId = { value: Int }
+
+{- | Unique identifier for templates. -}
+newtype TemplateId = { value: Int }
+
+newtype TableId = { value: Int }
+
+
 {- | What is this -}
 data Feature
  = EventFeature {

--- a/example/filter-expression.mcn
+++ b/example/filter-expression.mcn
@@ -1,3 +1,9 @@
 -- machinator @ v2
 
 record FilterExpression = { sql: String }
+
+
+{- | This is an example.
+     In Python, we just treat newtypes as synonyms.
+-}
+newtype Foo = { foo: int }

--- a/example/filter-expression.mcn
+++ b/example/filter-expression.mcn
@@ -14,6 +14,7 @@ record AggregateExpression = { sql: String }
 record PostAggregateExpression = { sql: String }
 
 {- | This is an example.
+
      In Python, we just treat newtypes as synonyms.
 -}
 newtype Example = { foo: int }

--- a/example/filter-expression.mcn
+++ b/example/filter-expression.mcn
@@ -7,3 +7,19 @@ record FilterExpression = { sql: String }
      In Python, we just treat newtypes as synonyms.
 -}
 newtype Foo = { foo: int }
+
+
+{- | Variant type. -}
+data Foo
+  = {- | The last, best chance for peace. -}
+     V1 {
+          name: String
+     }
+  |  {- | This has all happened before. -}
+     V2 {
+          names: List String,
+          age: Int,
+          height: Maybe Double,
+          wot: Foo,
+          bar: Maybe Bar
+     }

--- a/example/filter-expression.mcn
+++ b/example/filter-expression.mcn
@@ -1,12 +1,13 @@
 -- machinator @ v2
 
+{- | SQL expression to use when filtering input records. -}
 record FilterExpression = { sql: String }
 
 
 {- | This is an example.
      In Python, we just treat newtypes as synonyms.
 -}
-newtype Foo = { foo: int }
+newtype Example = { foo: int }
 
 
 {- | Variant type. -}
@@ -20,6 +21,6 @@ data Foo
           names: List String,
           age: Int,
           height: Maybe Double,
-          wot: Foo,
-          bar: Maybe Bar
+          parent: Maybe Foo,
+          bar: Size
      }

--- a/example/filter-expression.mcn
+++ b/example/filter-expression.mcn
@@ -4,6 +4,15 @@
 record FilterExpression = { sql: String }
 
 
+{- | SQL expression to use when selecting input records. -}
+record SelectExpression = { sql: String }
+
+{- | SQL expression to use when selecting input records. -}
+record AggregateExpression = { sql: String }
+
+{- | SQL expression to use when selecting input records. -}
+record PostAggregateExpression = { sql: String }
+
 {- | This is an example.
      In Python, we just treat newtypes as synonyms.
 -}

--- a/example/keywords.mcn
+++ b/example/keywords.mcn
@@ -1,0 +1,15 @@
+-- machinator @ v2
+
+{- | Check keyword handling in destination languages. -}
+data Foo
+    = {- | An example of Python keywords. -}
+      Python {
+        from: Int,
+        to: Int,
+        class: String
+      }
+    | {- | An example of Haskell keywords. -}
+      Haskell {
+        type: String,
+        class: Bool
+      }

--- a/example/keywords.mcn
+++ b/example/keywords.mcn
@@ -4,7 +4,7 @@
 newtype ExampleId = { id: Int }
 
 {- | Numbers. -}
-data Alt = One | Two | Three
+data Alt = One | Two | Three | LotsAndLots
 
 {- | Funny numbers. -}
 newtype BadAlt = { what: Alt }

--- a/example/keywords.mcn
+++ b/example/keywords.mcn
@@ -9,6 +9,9 @@ data Alt = One | Two | Three
 {- | Funny numbers. -}
 newtype BadAlt = { what: Alt }
 
+{- | Hello. -}
+newtype Ver = { this: UUID }
+
 {- | Check keyword handling in destination languages. -}
 data Foo
     = {- | An example of Python keywords. -}
@@ -16,11 +19,13 @@ data Foo
         id: ExampleId,
         from: Int,
         to: Int,
-        class: String
+        class: String,
+        ver: Maybe Ver
       }
     | {- | An example of Haskell keywords. -}
       Haskell {
         type: String,
         class: Bool,
-        wot: BadAlt
+        wot: BadAlt,
+        yes: Maybe (List Ver)
       }

--- a/example/keywords.mcn
+++ b/example/keywords.mcn
@@ -1,9 +1,19 @@
 -- machinator @ v2
 
+{- | Unique identifier for examples. -}
+newtype ExampleId = { id: Int }
+
+{- | Numbers. -}
+data Alt = One | Two | Three
+
+{- | Funny numbers. -}
+newtype BadAlt = { what: Alt }
+
 {- | Check keyword handling in destination languages. -}
 data Foo
     = {- | An example of Python keywords. -}
       Python {
+        id: ExampleId,
         from: Int,
         to: Int,
         class: String
@@ -11,5 +21,6 @@ data Foo
     | {- | An example of Haskell keywords. -}
       Haskell {
         type: String,
-        class: Bool
+        class: Bool,
+        wot: BadAlt
       }

--- a/machinator-core/src/Machinator/Core/Data/Definition.hs
+++ b/machinator-core/src/Machinator/Core/Data/Definition.hs
@@ -60,7 +60,7 @@ data Definition = Definition {
 -- | The module graph.
 -- Maps each file to the other files it depends on.
 newtype DefinitionFileGraph = DefinitionFileGraph {
-    unDefinitionFileGraph :: Map FilePath (Set FilePath)
+    unDefinitionFileGraph :: Map FilePath (Map FilePath (Set Name))
   } deriving (Eq, Ord, Show, Semigroup, Monoid, Data, Typeable, Generic)
 
 

--- a/machinator-core/src/Machinator/Core/Lexer.hs
+++ b/machinator-core/src/Machinator/Core/Lexer.hs
@@ -132,10 +132,9 @@ skipNotDocBlockCommentNested = p *> void (M.manyTill e n)
     n = C.string "-}"
 {-# INLINEABLE skipNotDocBlockCommentNested #-}
 
-
 ident :: Parser Token
 ident = do
-  s <- some M.alphaNumChar
+  s <- some (M.char '_' <|> M.alphaNumChar)
   pure (TIdent (T.pack s))
 
 -- -----------------------------------------------------------------------------

--- a/machinator-haskell/src/Machinator/Haskell/Scheme/Types.hs
+++ b/machinator-haskell/src/Machinator/Haskell/Scheme/Types.hs
@@ -37,7 +37,7 @@ types v ds =
 typesV1 :: [DefinitionFile] -> Either HaskellTypesError [(FilePath, Text)]
 typesV1 dfs =
   let DefinitionFileGraph fg = MG.buildFileGraph dfs
-      mg = M.mapKeys filePathToModuleName (fmap (S.map filePathToModuleName) fg)
+      mg = M.mapKeys filePathToModuleName (fmap (M.keysSet . M.mapKeys filePathToModuleName) fg)
   in for dfs $ \(DefinitionFile fp defs) ->
        let mn = filePathToModuleName fp in
        pure (genFileName mn, renderModule mn mg defs)

--- a/machinator-python/Setup.hs
+++ b/machinator-python/Setup.hs
@@ -1,0 +1,106 @@
+#!/usr/bin/env runhaskell
+
+import           Data.Char (isDigit, toLower)
+import           Data.Function (on)
+import           Data.List (intercalate, sortBy)
+import           Data.Monoid ((<>))
+import           Data.Version (showVersion)
+
+import           Distribution.InstalledPackageInfo
+import           Distribution.PackageDescription
+import           Distribution.Simple
+import           Distribution.Simple.Setup (BuildFlags(..), ReplFlags(..), TestFlags(..), fromFlag)
+import           Distribution.Simple.LocalBuildInfo
+import           Distribution.Simple.PackageIndex
+import           Distribution.Simple.BuildPaths (autogenModulesDir)
+import           Distribution.Simple.Utils (createDirectoryIfMissingVerbose, rewriteFile, rawSystemStdout)
+import           Distribution.Verbosity
+
+main :: IO ()
+main =
+  let hooks = simpleUserHooks
+   in defaultMainWithHooks hooks {
+     preConf = \args flags -> do
+       createDirectoryIfMissingVerbose silent True "gen"
+       (preConf hooks) args flags
+   , sDistHook  = \pd mlbi uh flags -> do
+       genBuildInfo silent pd
+       (sDistHook hooks) pd mlbi uh flags
+   , buildHook = \pd lbi uh flags -> do
+       genBuildInfo (fromFlag $ buildVerbosity flags) pd
+       genDependencyInfo (fromFlag $ buildVerbosity flags) pd lbi
+       (buildHook hooks) pd lbi uh flags
+   , replHook = \pd lbi uh flags args -> do
+       genBuildInfo (fromFlag $ replVerbosity flags) pd
+       genDependencyInfo (fromFlag $ replVerbosity flags) pd lbi
+       (replHook hooks) pd lbi uh flags args
+   , testHook = \args pd lbi uh flags -> do
+       genBuildInfo (fromFlag $ testVerbosity flags) pd
+       genDependencyInfo (fromFlag $ testVerbosity flags) pd lbi
+       (testHook hooks) args pd lbi uh flags
+   }
+
+genBuildInfo :: Verbosity -> PackageDescription -> IO ()
+genBuildInfo verbosity pkg = do
+  createDirectoryIfMissingVerbose verbosity True "gen"
+  let (PackageName pname) = pkgName . package $ pkg
+      version = pkgVersion . package $ pkg
+      name = "BuildInfo_" ++ (map (\c -> if c == '-' then '_' else c) pname)
+      targetHs = "gen/" ++ name ++ ".hs"
+      targetText = "gen/version.txt"
+  t <- timestamp verbosity
+  gv <- gitVersion verbosity
+  let v = showVersion version
+  let buildVersion = intercalate "-" [v, t, gv]
+  rewriteFile targetHs $ unlines [
+      "module " ++ name ++ " where"
+    , "import Prelude"
+    , "data RuntimeBuildInfo = RuntimeBuildInfo { buildVersion :: String, timestamp :: String, gitVersion :: String }"
+    , "buildInfo :: RuntimeBuildInfo"
+    , "buildInfo = RuntimeBuildInfo \"" ++ v ++ "\" \"" ++ t ++ "\" \"" ++ gv ++ "\""
+    , "buildInfoVersion :: String"
+    , "buildInfoVersion = \"" ++ buildVersion ++ "\""
+    ]
+  rewriteFile targetText buildVersion
+
+genDependencyInfo :: Verbosity -> PackageDescription -> LocalBuildInfo -> IO ()
+genDependencyInfo verbosity pkg info = do
+  let
+    (PackageName pname) = pkgName . package $ pkg
+    name = "DependencyInfo_" ++ (map (\c -> if c == '-' then '_' else c) pname)
+    targetHs = autogenModulesDir info ++ "/" ++ name ++ ".hs"
+    render p =
+      let
+        n = unPackageName $ pkgName p
+        v = intercalate "." . fmap show . versionBranch $ pkgVersion p
+      in
+       n ++ "-" ++ v
+    deps = fmap (render . sourcePackageId) . allPackages $ installedPkgs info
+    sdeps = sortBy (compare `on` fmap toLower) deps
+    strs = flip fmap sdeps $ \d -> "\"" ++ d ++ "\""
+
+  createDirectoryIfMissingVerbose verbosity True (autogenModulesDir info)
+
+  rewriteFile targetHs $ unlines [
+      "module " ++ name ++ " where"
+    , "import Prelude"
+    , "dependencyInfo :: [String]"
+    , "dependencyInfo = [\n    " ++ intercalate "\n  , " strs ++ "\n  ]"
+    ]
+
+gitVersion :: Verbosity -> IO String
+gitVersion verbosity = do
+  ver <- rawSystemStdout verbosity "git" ["log", "--pretty=format:%h", "-n", "1"]
+  notModified <- ((>) 1 . length) `fmap` rawSystemStdout verbosity "git" ["status", "--porcelain"]
+  return $ ver ++ if notModified then "" else "-M"
+
+timestamp :: Verbosity -> IO String
+timestamp verbosity =
+  rawSystemStdout verbosity "date" ["+%Y%m%d%H%M%S"] >>= \s ->
+    case splitAt 14 s of
+      (d, n : []) ->
+        if (length d == 14 && filter isDigit d == d)
+          then return d
+          else fail $ "date has failed to produce the correct format [" <> s <> "]."
+      _ ->
+        fail $ "date has failed to produce a date long enough [" <> s <> "]."

--- a/machinator-python/ambiata-machinator-python.cabal
+++ b/machinator-python/ambiata-machinator-python.cabal
@@ -49,7 +49,7 @@ executable gen-python
                      , ambiata-p
                      , ambiata-x-eithert
                      , ambiata-x-optparse
-                     , filepath
+                     , filepath                        == 1.4.*
                      , optparse-applicative            >= 0.10       && < 1.0
                      , text                            == 1.2.*
                      , transformers                    >= 0.4        && < 0.7

--- a/machinator-python/ambiata-machinator-python.cabal
+++ b/machinator-python/ambiata-machinator-python.cabal
@@ -48,6 +48,7 @@ executable gen-python
                      , ambiata-p
                      , ambiata-x-eithert
                      , ambiata-x-optparse
+                     , filepath
                      , optparse-applicative            >= 0.10       && < 1.0
                      , text                            == 1.2.*
                      , transformers                    >= 0.4        && < 0.7

--- a/machinator-python/ambiata-machinator-python.cabal
+++ b/machinator-python/ambiata-machinator-python.cabal
@@ -1,0 +1,106 @@
+name:                  ambiata-machinator-python
+version:               1.0.0
+license:               BSD3
+author:                Ambiata <info@ambiata.com>
+maintainer:            Ambiata <info@ambiata.com>
+copyright:             (c) 2017 Ambiata.
+synopsis:              ambiata-machinator-python
+category:              System
+cabal-version:         >= 1.8
+build-type:            Simple
+description:           ambiata-machinator-python
+
+library
+  build-depends:
+                       base                            >= 3          && < 5
+                     , ambiata-machinator-core
+                     , ambiata-p
+                     , ambiata-x-eithert
+                     , containers
+                     , filepath                        == 1.4.*
+                     , semigroups                      == 0.18.*
+                     , text                            == 1.2.*
+                     , transformers                    >= 0.4        && < 0.7
+                     , wl-pprint-annotated             == 0.1.*
+
+  ghc-options:
+                       -Wall
+
+  hs-source-dirs:
+                       src
+
+  exposed-modules:
+                       Machinator.Python
+                       Machinator.Python.Data.Types
+                       Machinator.Python.Scheme.Types
+                       Machinator.Python.Scheme.Types.Codegen
+
+
+executable gen-python
+  hs-source-dirs:      main
+  main-is:             Main.hs
+  ghc-options:         -Wall -threaded -O2
+
+  build-depends:
+                       base                            >= 3          && < 5
+                     , ambiata-machinator-core
+                     , ambiata-machinator-python
+                     , ambiata-p
+                     , ambiata-x-eithert
+                     , ambiata-x-optparse
+                     , optparse-applicative            >= 0.10       && < 1.0
+                     , text                            == 1.2.*
+                     , transformers                    >= 0.4        && < 0.7
+                     , directory                       == 1.3.*
+
+
+
+
+test-suite test
+  type:                exitcode-stdio-1.0
+
+  main-is:             test.hs
+
+  ghc-options:         -Wall -threaded -O2
+
+  hs-source-dirs:
+                       test
+
+  build-depends:
+                       base                            >= 3          && < 5
+                     , ambiata-disorder-core
+                     , ambiata-disorder-corpus
+                     , ambiata-disorder-jack
+                     , ambiata-p
+                     , ambiata-machinator-core
+                     , QuickCheck                      >= 2.8.2      && < 2.9
+                     , quickcheck-instances            == 0.3.*
+                     , semigroups
+                     , text
+
+test-suite test-io
+  type:                exitcode-stdio-1.0
+
+  main-is:             test-io.hs
+
+  ghc-options:         -Wall -threaded -O2
+
+  hs-source-dirs:
+                       test
+
+  build-depends:
+                       base                            >= 3          && < 5
+                     , ambiata-disorder-core
+                     , ambiata-disorder-corpus
+                     , ambiata-disorder-jack  
+                     , ambiata-p
+                     , ambiata-machinator-core
+                     , ambiata-machinator-core-test
+                     , QuickCheck                      >= 2.8.2      && < 2.9
+                     , quickcheck-instances            == 0.3.*
+                     , semigroups
+                     , text
+                     , directory
+                     , filepath
+                     , temporary                       == 1.2.*
+                     , process

--- a/machinator-python/ambiata-machinator-python.cabal
+++ b/machinator-python/ambiata-machinator-python.cabal
@@ -32,6 +32,7 @@ library
   exposed-modules:
                        Machinator.Python
                        Machinator.Python.Data.Types
+                       Machinator.Python.Mangle
                        Machinator.Python.Scheme.Types
                        Machinator.Python.Scheme.Types.Codegen
 

--- a/machinator-python/mafia
+++ b/machinator-python/mafia
@@ -1,0 +1,123 @@
+#!/bin/sh -eu
+
+: ${MAFIA_HOME:=$HOME/.mafia}
+
+fetch_latest () {
+  if [ -z ${MAFIA_TEST_MODE+x} ]; then
+    TZ=$(date +"%T")
+    curl --silent "https://raw.githubusercontent.com/ambiata/mafia/master/script/mafia?$TZ"
+  else
+    cat ../script/mafia
+  fi
+}
+
+latest_version () {
+  git ls-remote https://github.com/ambiata/mafia | grep refs/heads/master | cut -f 1
+}
+
+local_version () {
+  awk '/^# Version: / { print $3; exit 0; }' $0
+}
+
+run_upgrade () {
+  MAFIA_TEMP=$(mktemp 2>/dev/null || mktemp -t 'upgrade_mafia')
+
+  clean_up () {
+    rm -f "$MAFIA_TEMP"
+  }
+
+  trap clean_up EXIT
+
+  MAFIA_CUR="$0"
+
+  if [ -L "$MAFIA_CUR" ]; then
+    echo 'Refusing to overwrite a symlink; run `upgrade` from the canonical path.' >&2
+    exit 1
+  fi
+
+  echo "Checking for a new version of mafia ..."
+  fetch_latest > $MAFIA_TEMP
+
+  LATEST_VERSION=$(latest_version)
+  echo "# Version: $LATEST_VERSION" >> $MAFIA_TEMP
+
+  if ! cmp $MAFIA_CUR $MAFIA_TEMP >/dev/null 2>&1; then
+    mv $MAFIA_TEMP $MAFIA_CUR
+    chmod +x $MAFIA_CUR
+    echo "New version found and upgraded. You can now commit it to your git repo."
+  else
+    echo "You have latest mafia."
+  fi
+}
+
+exec_mafia () {
+  MAFIA_VERSION=$(local_version)
+
+  if [ "x$MAFIA_VERSION" = "x" ]; then
+    # If we can't find the mafia version, then we need to upgrade the script.
+    run_upgrade
+  else
+    MAFIA_BIN=$MAFIA_HOME/bin
+    MAFIA_FILE=mafia-$MAFIA_VERSION
+    MAFIA_PATH=$MAFIA_BIN/$MAFIA_FILE
+
+    [ -f "$MAFIA_PATH" ] || {
+      # Create a temporary directory which will be deleted when the script
+      # terminates. Unfortunately `mktemp` doesn't behave the same on
+      # Linux and OS/X so we need to try two different approaches.
+      MAFIA_TEMP=$(mktemp -d 2>/dev/null || mktemp -d -t 'exec_mafia')
+
+      # Create a temporary file in MAFIA_BIN so we can do an atomic copy/move dance.
+      mkdir -p $MAFIA_BIN
+
+      clean_up () {
+        rm -rf "$MAFIA_TEMP"
+      }
+
+      trap clean_up EXIT
+
+      echo "Building $MAFIA_FILE in $MAFIA_TEMP"
+
+      ( cd "$MAFIA_TEMP"
+
+        git clone https://github.com/ambiata/mafia
+        cd mafia
+
+        git reset --hard $MAFIA_VERSION
+
+        bin/bootstrap ) || exit $?
+
+      MAFIA_PATH_TEMP=$(mktemp --tmpdir=$MAFIA_BIN $MAFIA_FILE-XXXXXX 2>/dev/null || TMPDIR=$MAFIA_BIN mktemp -t $MAFIA_FILE)
+
+      clean_up_temp () {
+        clean_up
+        rm -f "$MAFIA_PATH_TEMP"
+      }
+      trap clean_up_temp EXIT
+
+      cp "$MAFIA_TEMP/mafia/.cabal-sandbox/bin/mafia" "$MAFIA_PATH_TEMP"
+      chmod 755 "$MAFIA_PATH_TEMP"
+      mv "$MAFIA_PATH_TEMP" "$MAFIA_PATH"
+
+      clean_up_temp
+    }
+
+    exec $MAFIA_PATH "$@"
+  fi
+}
+
+#
+# The actual start of the script.....
+#
+
+if [ $# -gt 0 ]; then
+  MODE="$1"
+else
+  MODE=""
+fi
+
+case "$MODE" in
+upgrade) shift; run_upgrade "$@" ;;
+*) exec_mafia "$@"
+esac
+# Version: 7c6993f5ad2ac2a605cbc46cd5a108358b5e8c06

--- a/machinator-python/main/Main.hs
+++ b/machinator-python/main/Main.hs
@@ -1,0 +1,52 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+
+import           Control.Monad.IO.Class (liftIO)
+
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+
+import           Options.Applicative
+
+import           P
+
+import           System.IO (IO, FilePath)
+import qualified System.IO as IO
+
+import           X.Control.Monad.Trans.Either (EitherT, hoistEither)
+import           X.Control.Monad.Trans.Either.Exit (orDie)
+
+import           Machinator.Core as Machinator
+import           Machinator.Python as Machinator
+
+
+
+inputs :: Parser [FilePath]
+inputs = many (strArgument (metavar "machinator"))
+
+main :: IO ()
+main = do
+  files       <- execParser opts
+  definitions <- orDie (T.pack . show) $ parseData files
+  results     <- orDie (T.pack . show) $ hoistEither $ typesV1 definitions
+
+  for_ results $ \(fp, contents) -> do
+    IO.putStrLn fp
+    IO.putStrLn "===="
+    T.putStrLn contents
+
+  where
+    opts = info (inputs <**> helper)
+      ( fullDesc
+     <> progDesc "Generate a Python client library from machinator source"
+     <> header "gen-python - generate Python client implementation" )
+
+parseData :: [FilePath] -> EitherT Machinator.MachinatorError IO [Machinator.DefinitionFile]
+parseData dfiles = do
+  for dfiles  $ \dfile -> do
+    t <- liftIO (T.readFile dfile)
+    Machinator.Versioned _v defs <-
+      hoistEither (Machinator.parseDefinitionFile dfile t)
+    pure defs
+

--- a/machinator-python/main/Main.hs
+++ b/machinator-python/main/Main.hs
@@ -11,16 +11,16 @@ import           Options.Applicative
 
 import           P
 
-import           System.Directory
+import           System.Directory (createDirectoryIfMissing)
 import           System.FilePath ((</>), takeDirectory, dropExtension)
 import           System.IO (IO, FilePath)
 import qualified System.IO as IO
+
 import           X.Control.Monad.Trans.Either (EitherT, hoistEither)
 import           X.Control.Monad.Trans.Either.Exit (orDie)
 
 import           Machinator.Core as Machinator
 import           Machinator.Python as Machinator
-
 
 data Options
   = Options
@@ -35,7 +35,6 @@ options :: Parser Options
 options = Options
   <$> strOption (long "target" <> metavar "DIR")
   <*> inputs
-
 
 main :: IO ()
 main = do

--- a/machinator-python/master.toml
+++ b/machinator-python/master.toml
@@ -1,0 +1,29 @@
+[master]
+  version = 1
+  runner = "s3://ambiata-dispensary-v2/dist/master/master-haskell/linux/x86_64/20160609072923-58d5481/master-haskell-20160609072923-58d5481"
+  sha1 = "f827e1ff43bcaa325d128662391d95a8b4d65525"
+[build.dist]
+  GHC_VERSION="7.10.2"
+  CABAL_VERSION = "1.22.4.0"
+[build.dist-7-8]
+  GHC_VERSION = "7.8.4"
+  CABAL_VERSION = "1.22.4.0"
+[build.branches-7-8]
+  GHC_VERSION = "7.8.4"
+  CABAL_VERSION = "1.22.4.0"
+[build.dist-7-10]
+  HADDOCK = "true"
+  HADDOCK_S3 = "$AMBIATA_HADDOCK_MASTER"
+  GHC_VERSION = "7.10.2"
+  CABAL_VERSION = "1.22.4.0"
+[build.branches-7-10]
+  HADDOCK = "true"
+  HADDOCK_S3 = "$AMBIATA_HADDOCK_BRANCHES"
+  GHC_VERSION = "7.10.2"
+  CABAL_VERSION = "1.22.4.0"
+[build.dist-8-0]
+  GHC_VERSION = "8.0.1"
+  CABAL_VERSION = "1.24.0.0"
+[build.branches-8-0]
+  GHC_VERSION = "8.0.1"
+  CABAL_VERSION = "1.24.0.0"

--- a/machinator-python/src/Machinator/Python.hs
+++ b/machinator-python/src/Machinator/Python.hs
@@ -1,0 +1,11 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Machinator.Python (
+    PythonTypesVersion (..)
+  , PythonTypesError (..)
+  , types
+  , typesV1
+  ) where
+
+import           Machinator.Python.Data.Types
+import           Machinator.Python.Scheme.Types

--- a/machinator-python/src/Machinator/Python/Data/Types.hs
+++ b/machinator-python/src/Machinator/Python/Data/Types.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Machinator.Python.Data.Types (
+    PythonTypesVersion (..)
+  , PythonTypesError (..)
+  , renderPythonTypesError
+  ) where
+
+
+import           P
+
+
+data PythonTypesVersion
+  = PythonTypesV1
+  deriving (Eq, Ord, Show, Bounded, Enum)
+
+data PythonTypesError
+  = PythonTypesError
+  deriving (Eq, Ord, Show)
+
+renderPythonTypesError :: PythonTypesError -> Text
+renderPythonTypesError pe =
+  case pe of
+    PythonTypesError ->
+      "PythonTypesError"

--- a/machinator-python/src/Machinator/Python/Mangle.hs
+++ b/machinator-python/src/Machinator/Python/Mangle.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Machinator.Python.Mangle where
+
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
+import           Data.Set (Set)
+import qualified Data.Set as S
+import qualified Data.Text as T
+
+import           Machinator.Core.Data.Definition
+
+import           P
+
+-- -----------------------------------------------------------------------------
+
+-- | Python keywords
+--
+-- https://docs.python.org/3/reference/lexical_analysis.html#keywords
+pythonKeywords :: Set T.Text
+pythonKeywords =
+  S.fromList [
+    "and", "as", "assert", "async", "await", "break", "class", "continue", "def",
+    "del", "elif", "else", "except", "False", "finally", "for", "from", "global",
+    "if", "import", "in", "is", "lambda", "None", "nonlocal", "not", "or",
+    "pass", "raise", "return", "True", "try", "while", "with", "yield"
+  ]
+
+-- | Map a set of names to be acceptible for use in Python.
+--
+-- Names are mangled when they are Python keywords.
+mangleNames :: Set Name -> Map Name Name
+mangleNames names = M.fromSet mangle names
+    where
+        suffix :: Name -> Name
+        suffix (Name t) =
+            let n' = Name (t <> "_")
+            in if n' `elem` names then suffix n' else n'
+        mangle :: Name -> Name
+        mangle n@(Name t)
+            | t `elem` pythonKeywords = suffix n
+            | otherwise = n
+
+-- -----------------------------------------------------------------------------

--- a/machinator-python/src/Machinator/Python/Scheme/Types.hs
+++ b/machinator-python/src/Machinator/Python/Scheme/Types.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Machinator.Python.Scheme.Types where
+
+
+import qualified Data.Char as Char
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
+import           Data.Set (Set)
+import qualified Data.Set as S
+import qualified Data.Text as T
+
+import           Machinator.Core
+import qualified Machinator.Core.Graph as MG
+import           Machinator.Python.Data.Types
+import qualified Machinator.Python.Scheme.Types.Codegen as Codegen
+
+import           P
+
+import qualified System.FilePath.Posix as FilePath
+import           System.IO (FilePath)
+
+
+types :: PythonTypesVersion -> [DefinitionFile] -> Either PythonTypesError [(FilePath, Text)]
+types v ds =
+  case v of
+    PythonTypesV1 ->
+      typesV1 ds
+
+typesV1 :: [DefinitionFile] -> Either PythonTypesError [(FilePath, Text)]
+typesV1 dfs =
+  let DefinitionFileGraph fg = MG.buildFileGraph dfs
+      mg = M.mapKeys filePathToModuleName (fmap (S.map filePathToModuleName) fg)
+  in for dfs $ \(DefinitionFile fp defs) ->
+       let mn = filePathToModuleName fp in
+       pure (genFileName mn, renderModule fp mn mg defs)
+
+-- -----------------------------------------------------------------------------
+
+renderModule :: FilePath -> ModuleName -> Map ModuleName (Set ModuleName) -> [Definition] -> Text
+renderModule fp mn@(ModuleName n) imports defs =
+  T.unlines [
+      "\"\"\"" <> n <> "\n\nGenerated from: " <> T.pack fp <> "\n\"\"\""
+    , maybe mempty (T.unlines . fmap renderImport . toList) (M.lookup mn imports)
+    , T.unlines . with defs $ \def ->
+        Codegen.genTypesV1 def
+    ]
+
+renderImport :: ModuleName -> Text
+renderImport (ModuleName n) =
+  "from " <> n <> " import *"
+
+
+-- -----------------------------------------------------------------------------
+
+newtype ModuleName = ModuleName {
+    _unModuleName :: Text
+  } deriving (Eq, Ord, Show)
+
+
+-- | Derive a module name from the relative 'FilePath'.
+--
+-- @
+-- λ> filePathToModuleName "./path_to/my/favourite_Template_place.hs"
+-- ModuleName {unModuleName = "PathTo.My.FavouriteTemplatePlace"}
+-- @
+--
+-- TODO V2 Accept an alternative function as a parameter.
+filePathToModuleName :: FilePath -> ModuleName
+filePathToModuleName =
+  ModuleName . T.pack . goLower . FilePath.dropExtension
+  where
+    -- Initial lower case
+    goLower [] = []
+    goLower (x:xs)
+      | Char.isAlphaNum x = Char.toLower x : goSnake xs
+      | otherwise = goSnake xs
+    -- Subsequent snake case
+    goSnake [] = []
+    goSnake (x:xs)
+      | x == '/'          = '.' : goLower xs
+      | Char.isUpper x    = '_' : Char.toLower x : goSnake xs
+      | Char.isAlphaNum x = x : goSnake xs
+      | otherwise         = '_' : goSnake xs
+
+genFileName :: ModuleName -> FilePath
+genFileName (ModuleName n) =
+  T.unpack (T.replace "." "/" n) <> ".py"

--- a/machinator-python/src/Machinator/Python/Scheme/Types.hs
+++ b/machinator-python/src/Machinator/Python/Scheme/Types.hs
@@ -41,7 +41,20 @@ renderModule :: FilePath -> ModuleName -> Map ModuleName (Set ModuleName) -> [De
 renderModule fp mn@(ModuleName n) imports defs =
   T.unlines [
       "\"\"\"" <> n <> "\n\nGenerated from: " <> T.pack fp <> "\n\"\"\""
+    -- TODO: We should only include these when required for this module.
+    , ""
+    , "import datetime"
+    , "import logging"
+    , "import uuid"
+    , ""
+    , "import jsonschema"
+    , ""
+    , ""
+    , "# Wot?"
+    , "# " <> T.pack (show mn)
+    , "# " <> T.pack (show (M.lookup mn imports))
     , maybe mempty (T.unlines . fmap renderImport . toList) (M.lookup mn imports)
+    , ""
     , T.unlines . with defs $ \def ->
         Codegen.genTypesV1 def
     ]
@@ -61,14 +74,14 @@ newtype ModuleName = ModuleName {
 -- | Derive a module name from the relative 'FilePath'.
 --
 -- @
--- λ> filePathToModuleName "./path_to/my/favourite_Template_place.hs"
--- ModuleName {unModuleName = "PathTo.My.FavouriteTemplatePlace"}
+-- λ> filePathToModuleName "./path_to/my/FavouriteTemplatePlace.mcn"
+-- ModuleName {unModuleName = "path_to.my.favourite_template_place"}
 -- @
 --
 -- TODO V2 Accept an alternative function as a parameter.
 filePathToModuleName :: FilePath -> ModuleName
 filePathToModuleName =
-  ModuleName . T.pack . goLower . FilePath.dropExtension
+  ModuleName . T.pack . FilePath.dropExtension
   where
     -- Initial lower case
     goLower [] = []

--- a/machinator-python/src/Machinator/Python/Scheme/Types.hs
+++ b/machinator-python/src/Machinator/Python/Scheme/Types.hs
@@ -39,27 +39,24 @@ typesV1 dfs =
 
 renderModule :: FilePath -> ModuleName -> Map ModuleName (Set ModuleName) -> [Definition] -> Text
 renderModule fp mn@(ModuleName n) imports defs =
-  T.unlines [
-      "\"\"\"Generated implementation of " <> n <> ".\"\"\""
-    -- TODO: We should only include these when required for this module.
+  T.unlines (
+    [ "\"\"\"Generated implementation of " <> n <> ".\"\"\""
     , ""
     , "# Generated from " <> T.pack fp
+    , ""
+    , "from __future__ import annotations"
     , ""
     , "import dataclasses  # noqa: F401"
     , "import datetime  # noqa: F401"
     , "import enum  # noqa: F401"
     , "import logging  # noqa: F401"
     , "import uuid  # noqa: F401"
-    , "from typing import Optional, List  # noqa: F401"
-    , ""
+    , "import typing  # noqa: F401"
     , "import jsonschema  # noqa: F401"
-    , "##"
-    , maybe mempty (T.unlines . fmap renderImport . toList) (M.lookup mn imports)
-    , "###"
-    , T.unlines . with defs $ \def ->
-        Codegen.genTypesV1 def
-    , "# EOF"
     ]
+    <> maybe mempty (("":) . fmap renderImport . toList) (mfilter (not . null) $ M.lookup mn imports)
+    <> with defs Codegen.genTypesV1
+  )
 
 renderImport :: ModuleName -> Text
 renderImport (ModuleName n) =

--- a/machinator-python/src/Machinator/Python/Scheme/Types.hs
+++ b/machinator-python/src/Machinator/Python/Scheme/Types.hs
@@ -48,6 +48,7 @@ renderModule fp mn@(ModuleName n) imports defs =
     , ""
     , "from __future__ import annotations"
     , ""
+    , "import abc  # noqa: F401"
     , "import dataclasses  # noqa: F401"
     , "import datetime  # noqa: F401"
     , "import enum  # noqa: F401"
@@ -65,7 +66,7 @@ renderImport (ModuleName n, ns) =
   let
     imports = (T.intercalate ", " . fmap unName . S.toAscList) ns
   in
-    "from " <> n <> " import " <> imports
+    "from .." <> n <> " import " <> imports
 
 
 -- -----------------------------------------------------------------------------

--- a/machinator-python/src/Machinator/Python/Scheme/Types.hs
+++ b/machinator-python/src/Machinator/Python/Scheme/Types.hs
@@ -7,7 +7,6 @@ import qualified Data.Char as Char
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import           Data.Set (Set)
-import qualified Data.Set as S
 import qualified Data.Text as T
 
 import           Machinator.Core
@@ -62,12 +61,7 @@ renderModule fp mn@(ModuleName n) imports defs =
   )
 
 renderImport :: (ModuleName, Set Name) -> Text
-renderImport (ModuleName n, ns) =
-  let
-    imports = (T.intercalate ", " . fmap unName . S.toAscList) ns
-  in
-    "from .." <> n <> " import " <> imports
-
+renderImport (ModuleName n, ns) = Codegen.genImportsV1 (Name n) ns
 
 -- -----------------------------------------------------------------------------
 

--- a/machinator-python/src/Machinator/Python/Scheme/Types.hs
+++ b/machinator-python/src/Machinator/Python/Scheme/Types.hs
@@ -40,23 +40,25 @@ typesV1 dfs =
 renderModule :: FilePath -> ModuleName -> Map ModuleName (Set ModuleName) -> [Definition] -> Text
 renderModule fp mn@(ModuleName n) imports defs =
   T.unlines [
-      "\"\"\"" <> n <> "\n\nGenerated from: " <> T.pack fp <> "\n\"\"\""
+      "\"\"\"" <> n <> "\"\"\""
     -- TODO: We should only include these when required for this module.
     , ""
-    , "import datetime"
-    , "import logging"
-    , "import uuid"
+    , "# Generated from " <> T.pack fp
     , ""
-    , "import jsonschema"
+    , "import dataclasses  # noqa: F401"
+    , "import datetime  # noqa: F401"
+    , "import enum  # noqa: F401"
+    , "import logging  # noqa: F401"
+    , "import uuid  # noqa: F401"
+    , "from typing import Optional, List  # noqa: F401"
     , ""
-    , ""
-    , "# Wot?"
-    , "# " <> T.pack (show mn)
-    , "# " <> T.pack (show (M.lookup mn imports))
+    , "import jsonschema  # noqa: F401"
+    , "##"
     , maybe mempty (T.unlines . fmap renderImport . toList) (M.lookup mn imports)
-    , ""
+    , "###"
     , T.unlines . with defs $ \def ->
         Codegen.genTypesV1 def
+    , "# EOF"
     ]
 
 renderImport :: ModuleName -> Text
@@ -81,7 +83,7 @@ newtype ModuleName = ModuleName {
 -- TODO V2 Accept an alternative function as a parameter.
 filePathToModuleName :: FilePath -> ModuleName
 filePathToModuleName =
-  ModuleName . T.pack . FilePath.dropExtension
+  ModuleName . T.pack . goLower . FilePath.dropExtension
   where
     -- Initial lower case
     goLower [] = []

--- a/machinator-python/src/Machinator/Python/Scheme/Types.hs
+++ b/machinator-python/src/Machinator/Python/Scheme/Types.hs
@@ -40,7 +40,7 @@ typesV1 dfs =
 renderModule :: FilePath -> ModuleName -> Map ModuleName (Set ModuleName) -> [Definition] -> Text
 renderModule fp mn@(ModuleName n) imports defs =
   T.unlines [
-      "\"\"\"" <> n <> "\"\"\""
+      "\"\"\"Generated implementation of " <> n <> ".\"\"\""
     -- TODO: We should only include these when required for this module.
     , ""
     , "# Generated from " <> T.pack fp

--- a/machinator-python/src/Machinator/Python/Scheme/Types.hs
+++ b/machinator-python/src/Machinator/Python/Scheme/Types.hs
@@ -42,7 +42,8 @@ renderModule fp mn@(ModuleName n) imports defs =
   T.unlines (
     [ "\"\"\"Generated implementation of " <> n <> ".\"\"\""
     , ""
-    , "# Generated from " <> T.pack fp
+    , "# WARNING DO NOT EDIT"
+    , "# This code was generated from " <> T.pack fp
     , ""
     , "from __future__ import annotations"
     , ""

--- a/machinator-python/src/Machinator/Python/Scheme/Types/Codegen.hs
+++ b/machinator-python/src/Machinator/Python/Scheme/Types/Codegen.hs
@@ -22,23 +22,23 @@ import qualified Text.PrettyPrint.Annotated.WL as WL
 
 -- | Generates a type declaration for the given definition.
 genTypesV1 :: Definition -> Text
-genTypesV1 def@(Definition _ mDoc _) =
-  renderText $ genTypesV1' def
+genTypesV1 def = renderText $ genTypesV1' def
 
 -- | Generates a type declaration for the given definition.
 genTypesV1' :: Definition -> Doc a
 genTypesV1' (Definition name@(Name n) mDoc dec) =
   case dec of
-    Variant (c1 :| cts) 
+    Variant (c1 :| cts)
       | isEnum (c1:cts) -> enum name mDoc (c1:cts)
       | otherwise       -> WL.vsep $
-                               dataclass n Nothing mDoc []
+                               dataclass name Nothing mDoc []
                              : fmap (uncurry3 (genConstructorV1 name)) (c1:cts)
 
     Record fts ->
       genRecordV1 name mDoc fts
 
-    Newtype ft@(_, t) ->
+    Newtype (_, t) ->
+      -- TODO: We may want to do something a little more useful here.
       WL.vsep [
         comment mDoc,
         WL.hsep [text n, WL.char '=', genTypeV1 t]
@@ -48,6 +48,8 @@ genTypeV1 :: Type -> Doc a
 genTypeV1 ty =
   case ty of
     Variable (Name n) ->
+      -- NB: We don't actually do anything with typevars. This case will probably
+      -- result in an error in the generated code.
       text n
     GroundT g ->
       case g of
@@ -73,8 +75,8 @@ genTypeV1 ty =
       string "Optional" <> WL.brackets (genTypeV1 t2)
 
 genConstructorV1 :: Name -> Name -> Maybe Docs -> [(Name, Type)] -> Doc a
-genConstructorV1 (Name extends) (Name constructorName) mDoc tys =
-    dataclass constructorName (Just extends) mDoc tys
+genConstructorV1 (Name extends) name =
+  dataclass name (Just extends)
 
 -- | Generates a naked record for the given definition.
 --
@@ -87,7 +89,7 @@ genRecordV1 (Name n) _ [] =
   WL.hang 2 $
     text "case object" <+> text n
 
-genRecordV1 (Name n) mDoc fts = dataclass n Nothing mDoc fts
+genRecordV1 name mDoc fts = dataclass name Nothing mDoc fts
 
 -- -----------------------------------------------------------------------------
 
@@ -107,15 +109,23 @@ comment :: Maybe Docs -> Doc a
 comment Nothing = WL.mempty
 comment (Just (Docs docs)) = WL.vsep $ fmap (\t -> text "#" WL.<+> text (T.strip t)) $ T.lines docs
 
-docstring :: Maybe Docs -> [Doc a]
-docstring Nothing = []
-docstring (Just (Docs docs)) =
+classDocstring :: Maybe Docs -> [(Name, Type)] -> [Doc a]
+classDocstring Nothing _ = []
+classDocstring (Just (Docs docs)) flds =
   let
     open  = string "\"\"\""
     close = string "\"\"\""
     trimmed = T.stripEnd (T.unlines (T.strip <$> T.lines docs))
+    args = WL.vsep [
+        WL.softbreak ,
+        text "Args:",
+        WL.indent 2 . WL.vsep $
+          fmap (\(Name n, ty) -> text n WL.<+> WL.parens (genTypeV1 ty) <> WL.char ':' WL.<+> string "A field") flds
+      ]
   in (:[]) . WL.group $
-    open <> WL.align (WL.pretty trimmed) <> close
+    open <> WL.align (
+      WL.pretty trimmed WL.<#> args
+    ) WL.<#> close
 
 -- | Converts a curried function to a function on a triple.
 uncurry3 :: (a -> b -> c -> d) -> ((a, b, c) -> d)
@@ -126,47 +136,47 @@ enum :: Name -> Maybe Docs -> [(Name, Maybe Docs, [(Name, Type)])] -> Doc a
 enum (Name n) mDoc ctors =
     WL.vsep [
       string "class" WL.<+> text n WL.<> WL.parens (string "enum.Enum") WL.<> ":",
-      WL.indent 4 . WL.vsep $ docstring mDoc <> fmap (\(Name m, _, []) -> WL.hsep [text m, WL.char '=', WL.dquotes $ text m]) ctors
+      WL.indent 4 . WL.vsep $ classDocstring mDoc [] <> fmap (\(Name m, _, []) -> WL.hsep [text m, WL.char '=', WL.dquotes $ text m]) ctors
     ] WL.<> WL.line
 
 
 -- | Generates a Python dataclass.
-dataclass :: Text -> Maybe Text -> Maybe Docs -> [(Name, Type)] -> Doc a
-dataclass name super mDoc flds = 
+dataclass :: Name -> Maybe Text -> Maybe Docs -> [(Name, Type)] -> Doc a
+dataclass name@(Name n) super mDoc flds =
   WL.vsep [
     string "@dataclass(frozen=True)",
-    string "class" <+> text name <> extends <> string ":",
-    WL.indent 4 . WL.vsep $ (docstring mDoc <> fields flds <> serde name flds),
+    string "class" <+> text n <> extends <> string ":",
+    WL.indent 4 . WL.vsep $ (classDocstring mDoc flds <> fields flds <> serde name flds),
     WL.line
   ]
   where
     extends =
       case super of
         Nothing -> WL.mempty
-        Just n -> WL.parens $ text n
+        Just sn -> WL.parens $ text sn
 
 fields :: [(Name, Type)] -> [Doc a]
 fields = fmap (\(Name n, t) -> text n WL.<> WL.char ':' WL.<+> genTypeV1 t)
 
-serde :: Text -> [(Name, Type)] -> [Doc a]
-serde _ _ =
+serde :: Name -> [(Name, Type)] -> [Doc a]
+serde n flds =
   [ WL.mempty
-  , classmethod "json_schema" []
-  , classmethod "from_json" [(Name "data", Right "dict")]
-  , method "to_json" []
+  , classmethod $ method "json_schema" [] (string "pass")
+  , generateFromJson n flds
+  , generateToJson n flds
   ]
 
-classmethod name args =
+classmethod :: Doc a -> Doc a
+classmethod body =
     WL.vsep [
-      string "@classmethod"
-    , string "def" WL.<+> text name WL.<> WL.encloseSep WL.lparen WL.rparen WL.comma (string "cls" : fmap arg args) WL.<> WL.char ':'
-    , WL.indent 4 $ string "pass"
-    ]  WL.<> WL.line
+      string "@classmethod", body
+    ]
 
-method name args =
+method :: Text -> [(Name, Either Type Text)] -> Doc a -> Doc a
+method name args body =
     WL.vsep [
       string "def" WL.<+> text name <> WL.encloseSep WL.lparen WL.rparen WL.comma (string "self" : fmap arg args) WL.<> WL.char ':'
-    , WL.indent 4 $ string "pass"
+    , WL.indent 4 body
     ] WL.<> WL.line
 
 arg :: (Name, Either Type Text) -> Doc a
@@ -180,3 +190,60 @@ isEnum cs = go cs
     go ((_, _, []):rs) = go rs
     go _ = False
 
+generateToJson :: Name -> [(Name, Type)] -> Doc a
+generateToJson cls flds =
+    method "to_json" [(Name "self", Left (Variable cls))] $ WL.vsep [
+      tripleQuote (text "Generate dictionary ready to be serialised to JSON."),
+      text "return dict" <> WL.parens (
+        WL.line <>
+        WL.indent 4 (WL.vsep (fmap serialiseField flds)) <>
+        WL.line
+      )
+    ]
+  where
+    serialiseField (Name f, ty) =
+      text f <> "=" <> serialiseType ("self." <> text f) ty
+
+generateFromJson :: Name -> [(Name, Type)] -> Doc a
+generateFromJson (Name n) flds =
+    classmethod . method "from_json" [(Name "data", Right "dict")] $ WL.vsep [
+      tripleQuote (text "Validate and parse JSON data into an instance of " <> text n <> "."),
+      text "return" WL.<+> text n <> WL.parens
+        (WL.line <> (WL.indent 4 . WL.vsep $ fmap parseField flds) <> WL.line)
+    ]
+  where
+    parseField (Name f, ty) =
+      text f <> "=" <> parseType ("data.get(\"" <> f <> "\")") ty
+
+tripleQuote :: Doc a -> Doc a
+tripleQuote s = text "\"\"\"" <> s <> text "\"\"\""
+
+serialiseType :: Doc a -> Type -> Doc a
+serialiseType value ty = case ty of
+  Variable na -> value <> ".to_json()"
+  GroundT gr -> case gr of
+    StringT -> value
+    BoolT -> value
+    IntT -> value
+    LongT -> value
+    DoubleT -> value
+    UUIDT -> "str(" <> value <> ")"
+    DateT -> value <> ".strfmt('%Y-%m-%d')"
+    DateTimeT -> value <> ".strfmt('%Y-%m-%dT%H:%M:%S.%f%z')"
+  ListT ty' -> "[" <> serialiseType "v" ty' <> " for v in " <> value <> "]"
+  MaybeT ty' -> "(lambda v: " <> serialiseType "v" ty' <> " if v is not None else None)(" <> value <> ")"
+
+parseType :: Text -> Type -> Doc a
+parseType value ty = case ty of
+  Variable (Name t) -> text t <> ".from_json(" <> text value <> ")"
+  GroundT gr -> case gr of
+    StringT -> "str(" <> text value <> ")"
+    BoolT -> "bool(" <> text value <> ")" -- TODO: This is wrong
+    IntT -> "int(" <> text value <> ")"
+    LongT -> "int(" <> text value <> ")"
+    DoubleT -> "float(" <> text value <> ")"
+    UUIDT -> "UUID(hex=" <> text value <> ")"
+    DateT -> "datetime.date()"
+    DateTimeT -> "datetime.datetime()"
+  ListT ty' -> "[" <> parseType "v" ty' <> " for v in " <> text value <> "]"
+  MaybeT ty' -> "(lambda v: " <> parseType "v" ty' <> " if v is not None else None)(" <> text value <> ")"

--- a/machinator-python/src/Machinator/Python/Scheme/Types/Codegen.hs
+++ b/machinator-python/src/Machinator/Python/Scheme/Types/Codegen.hs
@@ -1,0 +1,182 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Machinator.Python.Scheme.Types.Codegen (
+    genTypesV1
+
+  , genTypeV1
+  ) where
+
+
+import           Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+
+import           Machinator.Core
+import           Machinator.Core.Data.Definition
+
+import           P
+
+import           Text.PrettyPrint.Annotated.WL (Doc, (<+>))
+import qualified Text.PrettyPrint.Annotated.WL as WL
+
+
+-- | Generates a type declaration for the given definition.
+genTypesV1 :: Definition -> Text
+genTypesV1 def@(Definition _ mDoc _) =
+  renderText $ genTypesV1' def
+
+-- | Generates a type declaration for the given definition.
+genTypesV1' :: Definition -> Doc a
+genTypesV1' (Definition name@(Name n) mDoc dec) =
+  case dec of
+    Variant (c1 :| cts) 
+      | isEnum (c1:cts) -> enum name mDoc (c1:cts)
+      | otherwise       -> WL.vsep $
+                               dataclass n Nothing mDoc []
+                             : fmap (uncurry3 (genConstructorV1 name)) (c1:cts)
+
+    Record fts ->
+      genRecordV1 name mDoc fts
+
+    Newtype ft@(_, t) ->
+      WL.vsep [
+        comment mDoc,
+        WL.hsep [text n, WL.char '=', genTypeV1 t]
+      ]
+
+genTypeV1 :: Type -> Doc a
+genTypeV1 ty =
+  case ty of
+    Variable (Name n) ->
+      text n
+    GroundT g ->
+      case g of
+        StringT ->
+          text "str"
+        BoolT ->
+          text "bool"
+        IntT ->
+          text "int"
+        LongT ->
+          text "int"
+        DoubleT ->
+          text "float"
+        UUIDT ->
+          text "uuid.UUID"
+        DateT ->
+          text "datetime.date"
+        DateTimeT ->
+          text "datetime.datetime"
+    ListT t2 ->
+      text "List" WL.<> WL.brackets (genTypeV1 t2)
+    MaybeT t2 ->
+      string "Optional" <> WL.brackets (genTypeV1 t2)
+
+genConstructorV1 :: Name -> Name -> Maybe Docs -> [(Name, Type)] -> Doc a
+genConstructorV1 (Name extends) (Name constructorName) mDoc tys =
+    dataclass constructorName (Just extends) mDoc tys
+
+-- | Generates a naked record for the given definition.
+--
+-- @
+-- [(Name "foo", GroundT StringT), (Name "bar", GroundT StringT)]
+-- { foo :: String, bar :: String }
+-- @
+genRecordV1 :: Name -> Maybe Docs -> [(Name, Type)] -> Doc a
+genRecordV1 (Name n) _ [] =
+  WL.hang 2 $
+    text "case object" <+> text n
+
+genRecordV1 (Name n) mDoc fts = dataclass n Nothing mDoc fts
+
+-- -----------------------------------------------------------------------------
+
+string :: [Char] -> Doc a
+string =
+  WL.text
+
+text :: Text -> Doc a
+text =
+  WL.text . T.unpack
+
+renderText :: Doc a -> Text
+renderText =
+  TL.toStrict . WL.displayT . WL.renderPretty 0.8 100
+
+comment :: Maybe Docs -> Doc a
+comment Nothing = WL.mempty
+comment (Just (Docs docs)) = WL.vsep $ fmap (\t -> text "#" WL.<+> text (T.strip t)) $ T.lines docs
+
+docstring :: Maybe Docs -> [Doc a]
+docstring Nothing = []
+docstring (Just (Docs docs)) =
+  let
+    open  = string "\"\"\""
+    close = string "\"\"\""
+    trimmed = T.stripEnd (T.unlines (T.strip <$> T.lines docs))
+  in (:[]) . WL.group $
+    open <> WL.align (WL.pretty trimmed) <> close
+
+-- | Converts a curried function to a function on a triple.
+uncurry3 :: (a -> b -> c -> d) -> ((a, b, c) -> d)
+uncurry3 f ~(a,b,c) = f a b c
+
+-- | Generates a Python enumeration.
+enum :: Name -> Maybe Docs -> [(Name, Maybe Docs, [(Name, Type)])] -> Doc a
+enum (Name n) mDoc ctors =
+    WL.vsep [
+      string "class" WL.<+> text n WL.<> WL.parens (string "enum.Enum") WL.<> ":",
+      WL.indent 4 . WL.vsep $ docstring mDoc <> fmap (\(Name m, _, []) -> WL.hsep [text m, WL.char '=', WL.dquotes $ text m]) ctors
+    ] WL.<> WL.line
+
+
+-- | Generates a Python dataclass.
+dataclass :: Text -> Maybe Text -> Maybe Docs -> [(Name, Type)] -> Doc a
+dataclass name super mDoc flds = 
+  WL.vsep [
+    string "@dataclass(frozen=True)",
+    string "class" <+> text name <> extends <> string ":",
+    WL.indent 4 . WL.vsep $ (docstring mDoc <> fields flds <> serde name flds),
+    WL.line
+  ]
+  where
+    extends =
+      case super of
+        Nothing -> WL.mempty
+        Just n -> WL.parens $ text n
+
+fields :: [(Name, Type)] -> [Doc a]
+fields = fmap (\(Name n, t) -> text n WL.<> WL.char ':' WL.<+> genTypeV1 t)
+
+serde :: Text -> [(Name, Type)] -> [Doc a]
+serde _ _ =
+  [ WL.mempty
+  , classmethod "json_schema" []
+  , classmethod "from_json" [(Name "data", Right "dict")]
+  , method "to_json" []
+  ]
+
+classmethod name args =
+    WL.vsep [
+      string "@classmethod"
+    , string "def" WL.<+> text name WL.<> WL.encloseSep WL.lparen WL.rparen WL.comma (string "cls" : fmap arg args) WL.<> WL.char ':'
+    , WL.indent 4 $ string "pass"
+    ]  WL.<> WL.line
+
+method name args =
+    WL.vsep [
+      string "def" WL.<+> text name <> WL.encloseSep WL.lparen WL.rparen WL.comma (string "self" : fmap arg args) WL.<> WL.char ':'
+    , WL.indent 4 $ string "pass"
+    ] WL.<> WL.line
+
+arg :: (Name, Either Type Text) -> Doc a
+arg (Name n, t) = text n WL.<> WL.char ':' WL.<+> either genTypeV1 text t
+
+isEnum :: [(Name, Maybe Docs, [(Name, Type)])] -> Bool
+isEnum [] = False
+isEnum cs = go cs
+  where
+    go [] = True
+    go ((_, _, []):rs) = go rs
+    go _ = False
+

--- a/machinator-python/src/Machinator/Python/Scheme/Types/Codegen.hs
+++ b/machinator-python/src/Machinator/Python/Scheme/Types/Codegen.hs
@@ -133,7 +133,7 @@ discriminator :: Name -> [Doc a]
 discriminator (Name klass) =
   [
     WL.vsep
-      [ "ADT_TYPE" <> ":" <+> "typing.ClassVar" <> WL.brackets "str" <+> "=" <+> WL.dquotes (text klass)
+      [ "ADT_TYPE" <> ":" <+> "typing.ClassVar" <> WL.brackets "str" <+> "=" <+> (WL.dquotes . text . T.toLower) klass
       , "adt_type" <> ":" <+> "str" <+> "=" <+> "dataclasses.field(init=False, repr=False, default=ADT_TYPE)"
       ]
   ]
@@ -173,7 +173,7 @@ enum n@(Name klass) mDoc ctors =
       string "class" WL.<+> text klass WL.<> WL.parens (string "enum.Enum") WL.<> ":",
       WL.indent 4 . WL.vsep $ (
         googleDocstring mDoc [] Nothing [] <>
-        fmap (\(Name m) -> WL.hsep [text m, WL.char '=', WL.dquotes $ text m]) ctors <>
+        fmap (\(Name m) -> WL.hsep [text m, WL.char '=', WL.dquotes $ text (T.toLower m)]) ctors <>
         serdeEnum n ctors
       )
   ]
@@ -203,7 +203,7 @@ generateJsonSchemaEnum (Name klass) ctors =
     <> [
       "return " <> dict [
         ("type", WL.dquotes "string"),
-        ("enum", list $ fmap (WL.dquotes . text . unName) ctors)
+        ("enum", list $ fmap (WL.dquotes . text . T.toLower . unName) ctors)
       ]
     ]
   )

--- a/machinator-python/src/Machinator/Python/Scheme/Types/Codegen.hs
+++ b/machinator-python/src/Machinator/Python/Scheme/Types/Codegen.hs
@@ -2,12 +2,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Machinator.Python.Scheme.Types.Codegen (
     genTypesV1
-
   , genTypeV1
   ) where
 
 
 import           Data.List.NonEmpty (NonEmpty (..))
+import           Data.List (zipWith, tail)
 import qualified Data.Map.Strict as M
 import qualified Data.Set as S
 import qualified Data.Text as T
@@ -23,9 +23,16 @@ import qualified Text.PrettyPrint.Annotated.WL as WL
 
 import           Machinator.Python.Mangle
 
+
+-- | Name of the JSON property and field.
+discriminatorProperty :: Text
+discriminatorProperty = "adt_type"
+
+
 -- | Generates a type declaration for the given definition.
 genTypesV1 :: Definition -> Text
 genTypesV1 def = renderText $ genTypesV1' def
+
 
 -- | Generates a type declaration for the given definition.
 genTypesV1' :: Definition -> Doc a
@@ -39,8 +46,7 @@ genTypesV1' (Definition name mDoc dec) =
 
     Record fts          -> dataclass name Nothing mDoc fts
 
-    Newtype field      ->
-      dataclass name Nothing mDoc [field]
+    Newtype field       -> wrapperclass name Nothing mDoc field
 
 
 genTypeV1 :: Type -> Doc a
@@ -73,25 +79,37 @@ genTypeV1 ty =
     MaybeT t2 ->
       string "typing.Optional" <> WL.brackets (genTypeV1 t2)
 
-
 -- -----------------------------------------------------------------------------
 
-googleDocstring :: Maybe Docs -> [(Name, Type)] -> Maybe Text -> [Doc a]
-googleDocstring Nothing [] Nothing = []
-googleDocstring (Just (Docs docs)) [] Nothing = ["\"\"\"" WL.<> text (T.strip docs) WL.<> "\"\"\""]
-googleDocstring mDocs flds mRet =
+-- | Generate a Python docstring following Google's conventions.
+googleDocstring
+  :: Maybe Docs     -- ^ Documentation.
+  -> [(Name, Type)] -- ^ Arguments
+  -> Maybe Text     -- ^ Return value
+  -> [(Name, Text)] -- ^ Exceptions
+  -> [Doc a]
+googleDocstring Nothing [] Nothing _ = []
+googleDocstring (Just (Docs docs)) [] Nothing _ = ["\"\"\"" WL.<> text (T.strip docs) WL.<> "\"\"\""]
+googleDocstring mDocs flds mRet exc =
   let
     mangle = mangleNames . S.fromList $ fmap fst flds
-    args (nm@(Name n), ty) = (M.findWithDefault nm nm mangle, ty, Docs ("The '" <> n <> "' field."))
     trimmed = case mDocs of
       Just (Docs docs) -> text . T.strip <$> T.lines docs
       Nothing -> mempty
+    args (nm@(Name n), ty) = (M.findWithDefault nm nm mangle, ty, Docs ("The '" <> n <> "' field."))
     ret = case mRet of
       Nothing -> mempty
-      Just t ->  [WL.line <> "Returns:" WL.<#> WL.indent 4 (text t) <> WL.line]
+      Just t ->  [WL.line <> "Returns:" WL.<#> WL.indent 4 (text t)]
+    exceptions = case exc of
+      [] -> mempty
+      _ -> [
+          WL.line <> "Raises:" WL.<#> WL.indent 4 (
+            WL.vsep $ fmap (\(Name n, d) -> text n <> ": " <> text d) exc
+          )
+        ]
   in
     [
-      "\"\"\"" <> WL.vsep (trimmed <> arguments (fmap args flds) <> ret) WL.<#>
+      "\"\"\"" <> WL.vsep (trimmed <> arguments (fmap args flds) <> ret <> exceptions) WL.<#>
       "\"\"\""
     ]
 
@@ -116,27 +134,29 @@ isEnum cs = go cs
 
 -- | Generates a Python enumeration.
 enum :: Name -> Maybe Docs -> [(Name, Maybe Docs, [(Name, Type)])] -> Doc a
-enum (Name n) mDoc ctors =
+enum n@(Name klass) mDoc ctors =
   WL.linebreak WL.<#>
   WL.vsep [
-      string "class" WL.<+> text n WL.<> WL.parens (string "enum.Enum") WL.<> ":",
-      WL.indent 4 . WL.vsep $ googleDocstring mDoc [] Nothing <> fmap (\(Name m, _, []) -> WL.hsep [text m, WL.char '=', WL.dquotes $ text m]) ctors
+      string "class" WL.<+> text klass WL.<> WL.parens (string "enum.Enum") WL.<> ":",
+      WL.indent 4 . WL.vsep $ (
+        googleDocstring mDoc [] Nothing [] <>
+        fmap (\(Name m, _, []) -> WL.hsep [text m, WL.char '=', WL.dquotes $ text m]) ctors <>
+        enumserde n ctors
+      )
   ]
 
 
 superclass :: Name -> Maybe Docs -> Doc a
-superclass (Name n) mDoc =
+superclass name@(Name n) mDoc =
   WL.linebreak WL.<#>
   WL.vsep
     [ "@dataclasses.dataclass(frozen=True)"
     , "class" <+> text n <> ":"
     , WL.indent 4 . WL.vsep $ (
-        googleDocstring mDoc [] Nothing <>
+        googleDocstring mDoc [] Nothing [] <>
         [""] <>
-        [
-          "ADT_TYPE: typing.ClassVar[str] = ''",
-          "adt_type: str = dataclasses.field(default=ADT_TYPE, init=False, repr=False)"
-        ]
+        discriminator (Name "") <>
+        superserde name
       )
     ]
 
@@ -155,12 +175,51 @@ dataclass name@(Name n) super mDoc fieldDefs =
       [ string "@dataclasses.dataclass(frozen=True)"
       , string "class" <+> text n <> extends <> string ":"
       , WL.indent 4 . WL.vsep $ (
-          googleDocstring mDoc fieldDefs Nothing <>
+          googleDocstring mDoc fieldDefs Nothing [] <>
+          [""] <>
+          discriminator name <>
           [""] <>
           fields fieldDefs <>
           serde name fieldDefs
         )
       ]
+
+
+-- | Generates a Python wrapper dataclass.
+--
+-- This is our Python encoding of newtype wrappers.
+wrapperclass :: Name -> Maybe Name -> Maybe Docs -> (Name, Type) -> Doc a
+wrapperclass name@(Name n) super mDoc field =
+  let
+    extends =
+      case super of
+        Just (Name sn) -> WL.parens $ text sn
+        Nothing        -> WL.mempty
+  in
+    WL.linebreak WL.<#>
+    WL.vsep
+      [ string "@dataclasses.dataclass(frozen=True)"
+      , string "class" <+> text n <> extends <> string ":"
+      , WL.indent 4 . WL.vsep $ (
+          googleDocstring mDoc [field] Nothing [] <>
+          [""] <>
+          discriminator name <>
+          [""] <>
+          fields [field] <>
+          wrapperserde name field
+        )
+      ]
+
+
+-- | Generate fields to describe the discriminator.
+discriminator :: Name -> [Doc a]
+discriminator (Name klass) =
+  [
+    WL.vsep
+      [ "ADT_TYPE" <> ":" <+> "typing.ClassVar" <> WL.brackets "str" <+> "=" <+> WL.dquotes (text klass)
+      , "adt_type" <> ":" <+> "str" <+> "=" <+> "dataclasses.field(init=False, repr=False, default=ADT_TYPE)"
+      ]
+  ]
 
 
 -- | Generates Python dataclass definitions.
@@ -173,6 +232,204 @@ fields fs =
     field (nm, ty) = case M.findWithDefault nm nm mangle of
       Name n -> text n WL.<> WL.char ':' WL.<+> genTypeV1 ty
   in fmap field fs
+
+
+enumserde :: Name -> [(Name, Maybe Docs, [(Name, Type)])] -> [Doc a]
+enumserde n ctors =
+  [ WL.mempty
+  , generateEnumJsonSchema n (fmap (\(n, _, _) -> n) ctors)
+  , WL.mempty
+  , generateEnumFromJson n
+  , WL.mempty
+  , generateEnumToJson n
+  ]
+
+generateEnumJsonSchema :: Name -> [Name] -> Doc a
+generateEnumJsonSchema (Name klass) ctors =
+  classmethod . method "json_schema" "cls" [] $ WL.vsep (
+    googleDocstring
+      (Just . Docs $ "JSON schema for enumeration " <> klass <> ".")
+      []
+      Nothing
+      []
+    <> [
+      "return " <> dict [
+        ("type", WL.dquotes "string"),
+        ("enum", list $ fmap (WL.dquotes . text . unName) ctors)
+      ]
+    ]
+  )
+
+generateEnumFromJson :: Name -> Doc a
+generateEnumFromJson (Name klass) =
+  classmethod . method "from_json" "cls" [(Name "data", Right "dict")] $ WL.vsep (
+      googleDocstring
+        (Just . Docs $ "Validate and parse JSON data into an instance of " <> klass <> ".")
+        [(Name "data", Variable (Name "dict"))] -- "JSON dictionary to validate and parse."
+        (Just $ "An instance of " <> klass <> ".")
+        [
+          (Name "ValidationError", "When schema validation fails."),
+          (Name "KeyError", "When a required field is missing from the JSON.")
+        ]
+        <>
+      [
+        "try:",
+        WL.indent 4 . WL.vsep $ [
+          "jsonschema.validate" <> WL.encloseSep WL.lparen WL.rparen WL.comma [
+            "data",
+            "cls.json_schema()"
+          ],
+          text "return" WL.<+> text klass <> WL.parens ("str" <> WL.parens "data")
+        ],
+        "except jsonschema.exceptions.ValidationError as ex:",
+        WL.indent 4 . WL.vsep $ [
+          "logging.debug(\"Invalid JSON data received while parsing " <> text klass <> "\", exc_info=ex)",
+          "raise"
+        ]
+      ]
+    )
+
+generateEnumToJson :: Name -> Doc a
+generateEnumToJson _ =
+  method "to_json" "self" [] $ WL.vsep (
+    googleDocstring (Just (Docs "Serialise this instance as JSON.")) [] (Just "A dictionary ready to serialise as JSON.") [] <> [
+    text "return self.value"
+  ])
+
+
+
+-- | Generates JSON de-/serialise methods for a Python superclass.
+superserde :: Name -> [Doc a]
+superserde n =
+  [ WL.mempty
+  , generateSuperJsonSchema n
+  , WL.mempty
+  , generateSuperFromJson n
+  ]
+
+
+generateSuperJsonSchema :: Name -> Doc a
+generateSuperJsonSchema (Name klass) =
+  classmethod . method "json_schema" "cls" [] $ WL.vsep (
+    googleDocstring
+      (Just . Docs $ "JSON schema for variant " <> klass <> ".")
+      []
+      Nothing
+      []
+    <> [
+      "adt_types = [klass.ADT_TYPE for klass in cls.__subclasses__()]",
+      "return " <> dict [
+        ("type", WL.dquotes "object"),
+        ("properties", dict [
+          ("adt_type", dict [
+            ("type", WL.dquotes "string"),
+            ("enum", "adt_types")
+          ])
+        ])
+      ]
+    ]
+  )
+
+
+generateSuperFromJson :: Name -> Doc a
+generateSuperFromJson (Name klass) =
+  classmethod . method "from_json" "cls" [(Name "data", Right "dict")] $
+    WL.vsep (
+      googleDocstring
+        (Just . Docs $ "Validate and parse JSON data into an instance of " <> klass <> ".")
+        [(Name "data", Variable (Name "dict"))]
+        (Just $ "An instance of " <> klass <> ".")
+        [
+          (Name "ValidationError", "When schema validation fails."),
+          (Name "KeyError", "When a required field is missing from the JSON.")
+        ]
+      <> [
+        "try:",
+        WL.indent 4 . WL.vsep $ [
+          "jsonschema.validate" <> WL.encloseSep WL.lparen WL.rparen WL.comma [
+            "data",
+            "cls.json_schema()"
+          ],
+          "adt_type = data.get(" <> WL.dquotes (text discriminatorProperty) <> ", None)",
+          "for klass in cls.__subclasses__():",
+            WL.indent 4 (
+              "if klass.ADT_TYPE == adt_type:" WL.<#>
+                WL.indent 4 (
+                  "return" <+> "klass.from_json(data)"
+                )
+            )
+        ],
+        "except jsonschema.exceptions.ValidationError as ex:",
+        WL.indent 4 . WL.vsep $ [
+          "logging.debug(\"Invalid JSON data received while parsing " <> text klass <> "\", exc_info=ex)",
+          "raise"
+        ]
+      ]
+    )
+
+
+-- | Generates JSON de-/serialisation methods for a Python wrapper class.
+wrapperserde :: Name -> (Name, Type) -> [Doc a]
+wrapperserde n field =
+  [ WL.mempty
+  , generateWrapperJsonSchema n field
+  , WL.mempty
+  , generateWrapperFromJson n field
+  , WL.mempty
+  , generateWrapperToJson n field
+  ]
+
+
+generateWrapperJsonSchema :: Name -> (Name, Type) -> Doc a
+generateWrapperJsonSchema (Name n) (Name _, t) =
+  classmethod . method "json_schema" "cls" [] $ WL.vsep (
+    googleDocstring (Just . Docs $ "Return the JSON schema for " <> n <> " data.") [] (Just "JSON schema dictionary.") [] <> [
+      "return" <+> schemaType t
+    ]
+  )
+
+
+generateWrapperFromJson :: Name -> (Name, Type) -> Doc a
+generateWrapperFromJson (Name klass) (Name f, ty) =
+  classmethod . method "from_json" "cls" [(Name "data", Right "dict")] $ WL.vsep (
+      googleDocstring
+        (Just . Docs $ "Validate and parse JSON data into an instance of " <> klass <> ".")
+        [(Name "data", Variable (Name "dict"))] -- "JSON dictionary to validate and parse."
+        (Just $ "An instance of " <> klass <> ".")
+        [
+          (Name "ValidationError", "When schema validation fails."),
+          (Name "KeyError", "When a required field is missing from the JSON.")
+        ]
+        <>
+      [
+        "try:",
+        WL.indent 4 . WL.vsep $ [
+          "jsonschema.validate" <> WL.encloseSep WL.lparen WL.rparen WL.comma [
+            "data",
+            "cls.json_schema()"
+          ],
+          text "return" WL.<+> text klass <> WL.parens (parseType "data" ty)
+        ],
+        "except jsonschema.exceptions.ValidationError as ex:",
+        WL.indent 4 . WL.vsep $ [
+          "logging.debug(\"Invalid JSON data received while parsing " <> text klass <> "\", exc_info=ex)",
+          "raise"
+        ]
+      ]
+    )
+
+-- | Generate the JSON serialisation method for a dataclass.
+--
+-- Note that names have been mangled according to Python lexical rules. See 'fields'
+generateWrapperToJson :: Name -> (Name, Type) -> Doc a
+generateWrapperToJson _ (f, ty) =
+  let
+    Name field = M.findWithDefault f f (mangleNames (S.singleton f))
+  in
+    method "to_json" "self" [] $ WL.vsep (
+      googleDocstring (Just (Docs "Serialise this instance as JSON.")) [] (Just "A dictionary ready to serialise as JSON.") [] <> [
+      text "return " <> serialiseType ("self." <> text field) ty
+    ])
 
 
 -- | Generates JSON de-/serialise methods for a Python dataclass.
@@ -190,25 +447,29 @@ serde n flds =
 -- | Generate the JSON schema method for a Python dataclass.
 generateJsonSchema :: Name -> [(Name, Type)] -> Doc a
 generateJsonSchema (Name n) flds =
-    classmethod . method "json_schema" [] $ WL.vsep (
-      googleDocstring (Just (Docs $ "Return the JSON schema for " <> n <> " data.")) [] (Just "JSON schema dictionary.") <> [
-      "return dict" <> WL.parens (
-        WL.line <>
-        WL.indent 4 (WL.vsep
-          [ "type=\"object\","
-          , "properties={" WL.<#> WL.indent 4 (WL.vsep (fmap fieldSchema flds)) WL.<#> "},"
-          , "required=[" WL.<#> (WL.indent 4 . WL.vsep $ flds >>= requiredField) WL.<#> "]"
-        ]) <>
-        WL.line
-      )
+    classmethod . method "json_schema" "cls" [] $ WL.vsep (
+      googleDocstring (Just (Docs $ "Return the JSON schema for " <> n <> " data.")) [] (Just "JSON schema dictionary.") [] <> [
+      "return" <+> dict [
+        ("type", WL.dquotes "object"),
+        ("properties", dict (
+          (discriminatorProperty, dict [
+            ("type", WL.dquotes "string"),
+            ("enum", WL.list ["cls.ADT_TYPE"])
+          ]) :
+          fmap fieldSchema flds
+        )),
+        ("required", list $ WL.dquotes (text discriminatorProperty) : (flds >>= requiredField)
+        )
+      ]
     ])
   where
-    fieldSchema (Name f, ty) =
-      WL.dquotes (text f) <> ": " <> schemaType ty <> ","
+    fieldSchema :: (Name, Type) -> (Text, Doc a)
+    fieldSchema (Name f, ty) = (f, schemaType ty)
     requiredField (Name f, ty) =
       case ty of
         MaybeT _ -> []
-        _        -> [WL.dquotes (text f) <> ","]
+        _        -> [WL.dquotes (text f)]
+
 
 -- | Generate the Python encoding of the JSON schema for a type.
 schemaType :: Type -> Doc a
@@ -216,14 +477,14 @@ schemaType ty =
   case ty of
     Variable (Name v) -> text v <> ".json_schema()"
     GroundT gr -> case gr of
-      StringT -> "dict(type=\"string\")"
-      BoolT -> "dict(type=\"boolean\")"
-      IntT -> "dict(type=\"integer\")"
-      LongT -> "dict(type=\"integer\")"
-      DoubleT -> "dict(type=\"float\")"
-      UUIDT -> "dict(type=\"string\", format=\"uuid\")"
-      DateT -> "dict(type=\"string\", format=\"date\")"
-      DateTimeT -> "dict(type=\"string\", format=\"date-time\")"
+      StringT -> dict [("type", WL.dquotes "string")]
+      BoolT -> dict [("type", WL.dquotes "boolean")]
+      IntT -> dict [("type", WL.dquotes "integer")]
+      LongT -> dict [("type", WL.dquotes "integer")]
+      DoubleT -> dict [("type", WL.dquotes "float")]
+      UUIDT -> dict [("type", WL.dquotes "string"), ("format", WL.dquotes "uuid")]
+      DateT -> dict [("type", WL.dquotes "string"), ("format", WL.dquotes "date")]
+      DateTimeT -> dict [("type", WL.dquotes "string"), ("format", WL.dquotes "date-time")]
     ListT ty' -> "dict(type=\"array\", item="<> schemaType ty' <> ")"
     MaybeT ty' -> "dict(oneOf=[" WL.<#>
       WL.indent 4 (WL.vsep [
@@ -242,14 +503,12 @@ generateToJson _ fieldDefs =
     -- (fieldName, jsonProperty, type)
     properties = fmap (\(n, t) -> (M.findWithDefault n n mangle, n, t)) fieldDefs
     serialiseField (Name f, Name p, ty) =
-      WL.dquotes (text p) <> ": " <> serialiseType ("self." <> text f) ty <> ","
+      (p, serialiseType ("self." <> text f) ty)
   in
-    method "to_json" [] $ WL.vsep (
-      googleDocstring (Just (Docs "Serialise this instance as JSON.")) [] (Just "A dictionary ready to serialise as JSON.") <> [
-      text "return " <> WL.braces (
-        WL.line <>
-        WL.indent 4 (WL.vsep (fmap serialiseField properties)) <>
-        WL.line
+    method "to_json" "self" [] $ WL.vsep (
+      googleDocstring (Just (Docs "Serialise this instance as JSON.")) [] (Just "A dictionary ready to serialise as JSON.") [] <> [
+      text "return " <> dict (
+        (discriminatorProperty, "self.ADT_TYPE") : fmap serialiseField properties
       )
     ])
 
@@ -264,44 +523,41 @@ generateFromJson (Name klass) fieldDefs =
     parseField (Name f, Name p, ty) =
       text f <> "=" <> parseType ("data[\"" <> p <> "\"]") ty <> ","
   in
-    classmethod . method "from_json" [(Name "data", Right "dict")] $ WL.vsep [
-      "\"\"\"" <> "Validate and parse JSON data into an instance of " <> text klass <> "." WL.<#>
-      WL.line <>
-      "Args:" WL.<#>
-      WL.indent 4 "data (dict): JSON dictionary to validate and parse." WL.<#>
-      WL.line <>
-      "Returns:" WL.<#>
-      WL.indent 4 "An instance of " <> text klass <> "." WL.<#>
-      WL.line <>
-      "Raises:" WL.<#>
-      WL.indent 4 ( WL.vsep [
-        "ValidationError: When schema validation fails.",
-        "KeyError: When a required field is missing from the JSON."
-      ]) WL.<#>
-      "\"\"\"",
-      "try:",
-      WL.indent 4 . WL.vsep $ [
-        "jsonschema.validate" <> WL.encloseSep WL.lparen WL.rparen WL.comma [
-          "data",
-          "self.json_schema()"
+    classmethod . method "from_json" "cls" [(Name "data", Right "dict")] $ WL.vsep (
+      googleDocstring
+        (Just . Docs $ "Validate and parse JSON data into an instance of " <> klass <> ".")
+        [(Name "data", Variable (Name "dict"))] -- "JSON dictionary to validate and parse."
+        (Just $ "An instance of " <> klass <> ".")
+        [
+          (Name "ValidationError", "When schema validation fails."),
+          (Name "KeyError", "When a required field is missing from the JSON.")
+        ]
+        <>
+      [
+        "try:",
+        WL.indent 4 . WL.vsep $ [
+          "jsonschema.validate" <> WL.encloseSep WL.lparen WL.rparen WL.comma [
+            "data",
+            "cls.json_schema()"
+          ],
+          text "return" WL.<+> text klass <> WL.parens
+            (WL.line <> (WL.indent 4 . WL.vsep $ fmap parseField properties) <> WL.line)
         ],
-        text "return" WL.<+> text klass <> WL.parens
-          (WL.line <> (WL.indent 4 . WL.vsep $ fmap parseField properties) <> WL.line)
-      ],
-      "except jsonschema.exceptions.ValidationError as ex:",
-      WL.indent 4 . WL.vsep $ [
-        "logging.debug(\"Invalid JSON data received while parsing " <> text klass <> "\", exc_info=ex)",
-        "raise"
+        "except jsonschema.exceptions.ValidationError as ex:",
+        WL.indent 4 . WL.vsep $ [
+          "logging.debug(\"Invalid JSON data received while parsing " <> text klass <> "\", exc_info=ex)",
+          "raise"
+        ]
       ]
-    ]
+    )
 
 serialiseType :: Doc a -> Type -> Doc a
 serialiseType value ty = case ty of
   Variable _ -> value <> ".to_json()"
   GroundT gr -> case gr of
-    StringT -> value
+    StringT -> "str" <> WL.parens value
     BoolT -> value
-    IntT -> value
+    IntT -> "int" <> WL.parens value
     LongT -> value
     DoubleT -> value
     UUIDT -> "str(" <> value <> ")"
@@ -333,16 +589,34 @@ classmethod body =
     string "@classmethod", body
   ]
 
-method :: Text -> [(Name, Either Type Text)] -> Doc a -> Doc a
-method name args body =
+method :: Text -> Text -> [(Name, Either Type Text)] -> Doc a -> Doc a
+method name self args body =
   WL.vsep [
-    string "def" WL.<+> text name <> WL.encloseSep WL.lparen WL.rparen WL.comma (string "self" : fmap arg args) WL.<> WL.char ':'
+    string "def" WL.<+> text name <> WL.encloseSep WL.lparen WL.rparen WL.comma (text self : fmap arg args) WL.<> WL.char ':'
   , WL.indent 4 body
   ]
 
 arg :: (Name, Either Type Text) -> Doc a
 arg (Name n, t) =
   text n WL.<> WL.char ':' WL.<+> either genTypeV1 text t
+
+-- | Literal Python dictionary.
+dict :: [(Text, Doc a)] -> Doc a
+dict [] = "{}"
+dict fs =
+    "{" WL.<#> WL.indent 4 (WL.vsep (fmap field fs)) WL.<#> "}"
+  where
+    field (n, v) = WL.dquotes (text n) <> ":" WL.<+> v <> ","
+
+list :: [Doc a] -> Doc a
+list [] = "[]"
+list fs =
+  let
+    commas :: [Doc a]
+    commas = tail (fmap (const ",") fs) <> [""]
+    lst = zipWith (<>) fs commas
+  in
+    WL.brackets (WL.align $ WL.fillSep lst)
 
 string :: [Char] -> Doc a
 string =

--- a/machinator-python/src/Machinator/Python/Scheme/Types/Codegen.hs
+++ b/machinator-python/src/Machinator/Python/Scheme/Types/Codegen.hs
@@ -219,8 +219,14 @@ generateJsonSchemaEnum (Name klass) ctors =
       []
     <> [
       "return " <> dict [
-        ("type", WL.dquotes "string"),
-        ("enum", list $ fmap (WL.dquotes . text . T.toLower . unName) ctors)
+        ("type", WL.dquotes "object"),
+        ("properties", dict [
+          ("adt_type", dict [
+            ("type", WL.dquotes "string"),
+            ("enum", list $ fmap (WL.dquotes . text . T.toLower . unName) ctors)
+          ])
+        ]),
+        ("required", list [WL.dquotes (text discriminatorProperty)])
       ]
     ]
   )
@@ -246,7 +252,7 @@ generateFromJsonEnum (Name klass) =
             "data",
             "cls.json_schema()"
           ],
-          text "return" WL.<+> text klass <> WL.parens ("str" <> WL.parens "data")
+          text "return" WL.<+> text klass <> WL.parens ("str" <> WL.parens "data['adt_type']")
         ],
         "except jsonschema.exceptions.ValidationError as ex:",
         WL.indent 4 . WL.vsep $ [
@@ -262,7 +268,7 @@ generateToJsonEnum :: Doc a
 generateToJsonEnum =
   method "to_json" "self" [] $ WL.vsep (
     googleDocstring (Just (Docs "Serialise this instance as JSON.")) [] (Just "JSON data ready to be serialised.") [] <> [
-    text "return self.value"
+    text "return {'adt_type': self.value}"
   ])
 
 

--- a/machinator-python/test/test-io.hs
+++ b/machinator-python/test/test-io.hs
@@ -1,0 +1,5 @@
+import Disorder.Core.Main
+
+main :: IO ()
+main = disorderMain [
+  ]

--- a/machinator-python/test/test.hs
+++ b/machinator-python/test/test.hs
@@ -1,0 +1,5 @@
+import Disorder.Core.Main
+
+main :: IO ()
+main = disorderMain [
+  ]

--- a/machinator-scala/ambiata-machinator-scala.cabal
+++ b/machinator-scala/ambiata-machinator-scala.cabal
@@ -50,6 +50,7 @@ executable gen-scala
                      , ambiata-x-eithert
                      , ambiata-x-optparse
                      , optparse-applicative            >= 0.10       && < 1.0
+                     , filepath                        == 1.4.*
                      , text                            == 1.2.*
                      , transformers                    >= 0.4        && < 0.7
                      , directory                       == 1.3.*

--- a/machinator-scala/src/Machinator/Scala/Scheme/Types.hs
+++ b/machinator-scala/src/Machinator/Scala/Scheme/Types.hs
@@ -7,7 +7,6 @@ import qualified Data.Char as Char
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import           Data.Set (Set)
-import qualified Data.Set as S
 import qualified Data.Text as T
 
 import           Machinator.Core
@@ -31,7 +30,7 @@ types v ds =
 typesV1 :: [DefinitionFile] -> Either ScalaTypesError [(FilePath, Text)]
 typesV1 dfs =
   let DefinitionFileGraph fg = MG.buildFileGraph dfs
-      mg = M.mapKeys filePathToModuleName (fmap (S.map filePathToModuleName) fg)
+      mg = M.mapKeys filePathToModuleName (fmap (M.keysSet . M.mapKeys filePathToModuleName) fg)
   in for dfs $ \(DefinitionFile fp defs) ->
        let mn = filePathToModuleName fp in
        pure (genFileName mn, renderModule mn mg defs)


### PR DESCRIPTION
Generate Python code from machinator declarations.

General changes

1. The file dependency graph now includes the names being imported from each file.
2. The Python and Scala generators create files instead of printing to standard out.
3. Names can contain `_` characters.

Python

1. Field names are mangled with `_`s to avoid reserved words. Hopefully type and constructor names will be OK.
2. Record types generate a regular Python dataclass.
3. Variant types generate a superclass and one dataclass per constructor.
4. But variant types with no fields generate an Enum class.
5. Newtypes generate a dataclass with a single field and special JSON serde methods.
6. All of these types have `json_schema`, `to_json` and `from_json` methods.