### PR TITLE
Add Map to source language, lift common variant fields in Scala, ...

### DIFF
--- a/machinator-core/src/Machinator/Core/Data/Version.hs
+++ b/machinator-core/src/Machinator/Core/Data/Version.hs
@@ -30,6 +30,7 @@ import           P
 data MachinatorVersion
   = MachinatorV1
   | MachinatorV2
+  | MachinatorV3
   deriving (Eq, Ord, Enum, Show)
 
 versionToNumber :: Integral a => MachinatorVersion -> a
@@ -39,6 +40,8 @@ versionToNumber v =
       1
     MachinatorV2 ->
       2
+    MachinatorV3 ->
+      3
 
 versionFromNumber :: (Alternative f, Integral a) => a -> f MachinatorVersion
 versionFromNumber i =
@@ -47,6 +50,8 @@ versionFromNumber i =
       pure MachinatorV1
     2 ->
       pure MachinatorV2
+    3 ->
+      pure MachinatorV3
     _ ->
       empty
 
@@ -60,6 +65,7 @@ data MachinatorFeature
   = HasStrings
   | HasVariants
   | HasLists
+  | HasMaps
   | HasRecords
   | HasBools
   | HasComments
@@ -83,6 +89,17 @@ versionFeatures mv =
           HasStrings
         , HasVariants
         , HasLists
+        , HasRecords
+        , HasBools
+        , HasComments
+        ]
+
+    MachinatorV3 ->
+      S.fromList [
+          HasStrings
+        , HasVariants
+        , HasLists
+        , HasMaps
         , HasRecords
         , HasBools
         , HasComments

--- a/machinator-core/src/Machinator/Core/Parser.hs
+++ b/machinator-core/src/Machinator/Core/Parser.hs
@@ -246,6 +246,8 @@ types' v = do
   case x of
     Name "List" ->
       hasFeature v HasLists *> (ListT <$> types v)
+    Name "Map" ->
+      hasFeature v HasMaps  *> (MapT <$> types v <*> types v)
     Name "Maybe" ->
       hasFeature v HasLists *> (MaybeT <$> types v)
     _ ->

--- a/machinator-core/src/Machinator/Core/Pretty.hs
+++ b/machinator-core/src/Machinator/Core/Pretty.hs
@@ -141,6 +141,11 @@ ppType p t =
         punctuation "(" WL.<> primitive "Maybe" <+> ppType 11 lt WL.<> punctuation ")"
       else
         primitive "Maybe" <+> ppType 11 lt
+    MapT k v ->
+      if p > 10 then
+        punctuation "(" WL.<> primitive "Map" <+> ppType 11 k <+> ppType 11 v WL.<> punctuation ")"
+      else
+        primitive "Map" <+> ppType 11 k <+> ppType 11 v
 
 ppGroundType :: Ground -> Doc SyntaxAnnotation
 ppGroundType =

--- a/machinator-python/src/Machinator/Python/Scheme/Types.hs
+++ b/machinator-python/src/Machinator/Python/Scheme/Types.hs
@@ -51,10 +51,11 @@ renderModule fp mn@(ModuleName n) imports defs =
     , "import dataclasses  # noqa: F401"
     , "import datetime  # noqa: F401"
     , "import enum  # noqa: F401"
-    , "import logging  # noqa: F401"
-    , "import uuid  # noqa: F401"
-    , "import typing  # noqa: F401"
+    , "import json  # noqa: F401"
     , "import jsonschema  # noqa: F401"
+    , "import logging  # noqa: F401"
+    , "import typing  # noqa: F401"
+    , "import uuid  # noqa: F401"
     ]
     <> maybe mempty (("":) . fmap renderImport . M.toList) (mfilter (not . null) $ M.lookup mn imports)
     <> with defs Codegen.genTypesV1

--- a/machinator-python/src/Machinator/Python/Scheme/Types/Codegen.hs
+++ b/machinator-python/src/Machinator/Python/Scheme/Types/Codegen.hs
@@ -89,7 +89,7 @@ genTypeV1 ty =
     MaybeT t2 ->
       string "typing.Optional" <> WL.brackets (genTypeV1 t2)
     MapT k v ->
-      text "typing.Dict" <> (WL.brackets . WL.hcat) (WL.punctuate "," [genTypeV1 k, genTypeV1 v])
+      text "typing.Dict" <> (WL.brackets . WL.hcat) (WL.punctuate ", " [genTypeV1 k, genTypeV1 v])
 
 -- -----------------------------------------------------------------------------
 

--- a/machinator-python/src/Machinator/Python/Scheme/Types/Codegen.hs
+++ b/machinator-python/src/Machinator/Python/Scheme/Types/Codegen.hs
@@ -187,22 +187,25 @@ isEnum cs = go cs
 -- | Generates a Python enumeration.
 enum :: Name -> Maybe Docs -> [(Name, Maybe Docs)] -> Doc a
 enum n@(Name klass) mDoc ctors =
+  let
+    instances = fmap (first instanceName) ctors
+  in
     WL.linebreak WL.<#>
     WL.vsep [
         string "class" WL.<+> text klass WL.<> WL.parens (string "enum.Enum") WL.<> ":",
         WL.indent 4 . WL.vsep $ (
           googleDocstring mDoc [] Nothing [] <>
-          fmap def ctors <>
-          serdeEnum n (fmap fst ctors)
+          fmap def instances <>
+          serdeEnum n (fmap fst instances)
         )
     ]
   where
+    instanceName (Name n) = Name (if klass `T.isSuffixOf` n then T.dropEnd (T.length klass) n else n)
     def (Name m, doc) =
-      let d = WL.hsep [text m, WL.char '=', WL.dquotes $ (text . T.toLower . value) m]
+      let d = WL.hsep [text  m, WL.char '=', WL.dquotes $ (text . T.toLower) m]
       in case doc of
         Nothing -> d
         docs -> WL.vsep (d : googleDocstring docs [] Nothing [])
-    value v = T.toLower $ if klass `T.isSuffixOf` v then T.dropEnd (T.length klass) v else v
 
 
 -- | Generate the JSON de-/serialisation methods for an enumeration.
@@ -214,6 +217,8 @@ serdeEnum n ctors =
   , generateFromJsonEnum n
   , WL.mempty
   , generateToJsonEnum
+  , WL.mempty
+  , generateJsonKeyEnum n
   ]
 
 
@@ -244,7 +249,7 @@ generateJsonSchemaEnum (Name klass) ctors =
 -- | Generate the JSON parsing method for an enumeration.
 generateFromJsonEnum :: Name -> Doc a
 generateFromJsonEnum (Name klass) =
-  classmethod . method "from_json" "cls" [(Name "data", Left (GroundT StringT))] $ WL.vsep (
+  classmethod . method "from_json" "cls" [(Name "data", Right "dict")] $ WL.vsep (
       googleDocstring
         (Just . Docs $ "Validate and parse JSON data into an instance of " <> klass <> ".")
         [(Name "data", GroundT StringT, "JSON data to validate and parse.")]
@@ -270,6 +275,37 @@ generateFromJsonEnum (Name klass) =
         ]
       ]
     )
+
+
+-- | Generated the JSON de-/derialisations methods for enumerations used as a key.
+generateJsonKeyEnum :: Name -> Doc a
+generateJsonKeyEnum (Name klass) =
+    WL.vsep [
+        fromKey
+      , WL.mempty
+      , toKey
+    ]
+  where
+    fromKey =
+      classmethod . method "from_json_key" "cls" [(Name "data", Right "str")] $ WL.vsep (
+        googleDocstring
+          (Just . Docs $ "Validate and parse a value from a JSON dictionary key.")
+          [(Name "data", GroundT StringT, "JSON data to validate and parse.")]
+          (Just $ "An instance of " <> klass <> ".")
+          []
+        <> [
+          "return" <+> text klass <> WL.parens ("str" <> WL.parens "data")
+        ]
+      )
+    toKey =
+      method "to_json_key" "self" [] $ WL.vsep (
+        googleDocstring
+          (Just . Docs $ "Serialised this instanse as a JSON string for use as a dictionary key.")
+          []
+          (Just $ "A JSON string ready to be used as a key.")
+          []
+        <> ["return" <+> "str" <> WL.parens "self.value"]
+      )
 
 
 -- | Generate the JSON serialisation method for an enumeration.
@@ -319,8 +355,35 @@ serdeWrapper n field@(_, ty) =
   , generateFromJsonWrapper n ty
   , WL.mempty
   , generateToJsonWrapper n field
-  ]
+  ] <> generateJsonKeysWrapper n field
 
+
+generateJsonKeysWrapper :: Name -> (Name, Type) -> [Doc a]
+generateJsonKeysWrapper (Name klass) (Name field, ty) =
+    fromMaybe [] . with (format ty) $ \(parse, print) ->
+      [ WL.mempty
+      , classmethod . method "from_json_key" "cls" [(Name "data", Right "str")] $ WL.vsep [
+          "\"\"\"Parse a JSON string such as a dictionary key.\"\"\"",
+          "return" <+> text klass <> WL.parens (parse <> WL.parens "data")
+        ]
+      , WL.mempty
+      , method "to_json_key" "self" [] $ WL.vsep [
+          "\"\"\"Serialise as a JSON string suitable for use as a dictionary key.\"\"\"",
+          "return" <+> print <> WL.parens ("self." <> text field)
+        ]
+      ]
+  where
+    format :: Type -> Maybe (Doc a, Doc a)
+    format (GroundT t) = case t of
+      StringT -> Just ("str", "str")
+      BoolT -> Just ("bool", "str")
+      IntT -> Just ("int", "str")
+      LongT -> Just ("int", "str")
+      DoubleT -> Just ("float", "str")
+      UUIDT -> Just ("(lambda s: uuid.UUID(hex=s))", "str")
+      DateT -> Just ("datetime.date.fromisoformat", "(lambda d: d.isoformat())")
+      DateTimeT -> Just ("(lambda s: datetime.datetime.strptime(s, '%Y-%m-%dT%H:%M:%S.%f%z'))", "(lambda d: d.strftime('%Y-%m-%dT%H:%M:%S.%f%z'))")
+    format _ = Nothing
 
 -- | Generate magic methods that delegate to the wrapped value.
 generateMagicMethods :: (Name, Type) -> [Doc a]
@@ -693,6 +756,22 @@ schemaType ty =
         ("additionalProperties", schemaType v)
       ]
 
+-- | JSON keys are strings, we need to serialise the JSON encoding to a string.
+serialiseKey :: Doc a -> Type -> Doc a
+serialiseKey value ty = case ty of
+  Variable _ -> value <> ".to_json_key()"
+  GroundT gr -> case gr of
+    StringT -> "str" <> WL.parens value
+    BoolT -> "str" <> WL.parens value
+    IntT -> "str" <> WL.parens value
+    LongT -> "str" <> WL.parens value
+    DoubleT -> "str" <> WL.parens value
+    UUIDT -> "str" <> WL.parens value
+    DateT -> value <> ".isoformat()"
+    DateTimeT -> value <> ".strftime('%Y-%m-%dT%H:%M:%S.%f%z')" -- TODO: We should force timezones?
+  ListT _ -> "raise ValueError('Cannot use lists as keys')"
+  MaybeT _ -> "raise ValueError('Cannot use optional values as keys')"
+  MapT _ _ -> "raise ValueError('Cannot use maps as keys')"
 
 -- | Generate the Python expression to serialise a type to JSON.
 serialiseType :: Doc a -> Type -> Doc a
@@ -710,12 +789,30 @@ serialiseType value ty = case ty of
   ListT ty' -> "[" <> serialiseType "v" ty' <> " for v in " <> value <> "]"
   MaybeT ty' -> "(" <> "lambda v: v and " <> serialiseType "v" ty' <> ")(" <> value <> ")"
   -- TODO: This just blindly assumes that k will be serialised to a str and not any other JSON document.
-  MapT k v -> "{" <> serialiseType "k" k <> ":" <+> serialiseType "v" v <+> "for" <+> "k, v" <+> "in" <+> value <> "}"
+  MapT k v -> "{" <> serialiseKey "k" k <> ":" <+> serialiseType "v" v <+> "for" <+> "k, v" <+> "in" <+> value <> ".items()}"
+
+
+-- | JSON keys are strings, we need to serialise the JSON encoding to a string.
+parseKey :: Doc a -> Type -> Doc a
+parseKey value ty = case ty of
+  Variable (Name t) -> text t <> ".from_json_key" <> WL.parens value
+  GroundT gr -> case gr of
+    StringT -> "str" <> WL.parens value
+    BoolT -> "bool" <> WL.parens value -- TODO
+    IntT -> "int" <> WL.parens value
+    LongT -> "int" <> WL.parens value
+    DoubleT -> "float" <> WL.parens value
+    UUIDT -> "uuid.UUID" <> WL.parens ("hex=" <> value)
+    DateT -> "datetime.date.fromisoformat" <> WL.parens value
+    DateTimeT -> "datetime.datetime.strptime("<> value <> ", '%Y-%m-%dT%H:%M:%S.%f%z')"
+  ListT _ -> "raise ValueError('Cannot use lists as keys')"
+  MaybeT _ -> "raise ValueError('Cannot use optional values as keys')"
+  MapT _ _ -> "raise ValueError('Cannot use maps as keys')"
 
 -- | Generate the Python expression to parse a type from JSON.
 parseType :: Doc a -> Type -> Doc a
 parseType value ty = case ty of
-  Variable (Name t) -> text t <> ".from_json(" <> value <> ")"
+  Variable (Name t) -> text t <> ".from_json" <> WL.parens value
   GroundT gr -> case gr of
     -- TODO: We validate before parsing, so at least some of these probably aren't necessary.
     StringT -> "str" <> WL.parens value
@@ -737,7 +834,7 @@ parseType value ty = case ty of
   MapT k v ->
     WL.group (
       "{" WL.<##>
-        flatIndent 4 (parseType "k" k <> ":" <+> parseType "v" v <+> "for" <+> "k, v" <+> "in" <+> value) WL.<##>
+        flatIndent 4 (parseKey "k" k <> ":" <+> parseType "v" v <+> "for" <+> "k, v" <+> "in" <+> value <> ".items()") WL.<##>
       "}"
     )
 

--- a/machinator-scala/main/Main.hs
+++ b/machinator-scala/main/Main.hs
@@ -12,7 +12,7 @@ import           Options.Applicative
 import           P
 
 import           System.Directory (createDirectoryIfMissing)
-import           System.FilePath ((</>), takeDirectory, dropExtension)
+import           System.FilePath ((</>), takeDirectory)
 import           System.IO (IO, FilePath)
 import qualified System.IO as IO
 
@@ -25,6 +25,7 @@ import           Machinator.Scala as Machinator
 data Options
   = Options
     { targetDirectory :: FilePath  -- ^ Directory to write output files.
+    , package :: Text              -- ^ Scala package name.
     , sourceFiles :: [FilePath]    -- ^ Input files.
     }
 
@@ -34,13 +35,14 @@ inputs = many (strArgument (metavar "machinator"))
 options :: Parser Options
 options = Options
   <$> strOption (long "target" <> metavar "DIR")
+  <*> strOption (long "package" <> metavar "PKG")
   <*> inputs
 
 main :: IO ()
 main = do
-  (Options out files) <- execParser opts
+  (Options out pkg files) <- execParser opts
   definitions <- orDie (T.pack . show) $ parseData files
-  results     <- orDie (T.pack . show) $ hoistEither $ typesV1 definitions
+  results     <- orDie (T.pack . show) $ hoistEither $ typesV1 pkg definitions
 
   for_ results $ \(fp, contents) -> do
     let dest = out </> fp

--- a/machinator-scala/src/Machinator/Scala/Scheme/Circe/Codegen.hs
+++ b/machinator-scala/src/Machinator/Scala/Scheme/Circe/Codegen.hs
@@ -46,7 +46,6 @@ generateToJsonV1Companion def@(M.Definition (M.Name tn) _ _) =
 
 typeNameV1 :: M.Definition -> Doc a
 typeNameV1 (M.Definition (M.Name tn) _ (M.Variant _)) = text tn
-typeNameV1 (M.Definition (M.Name tn) _ (M.Record [])) = text tn <> ".type"
 typeNameV1 (M.Definition (M.Name tn) _ (M.Record _)) = text tn
 typeNameV1 (M.Definition (M.Name tn) _ (M.Newtype _)) = text tn
 
@@ -76,13 +75,6 @@ generateToJsonV1 def@(M.Definition (M.Name tn) _ typ) =
                           field "adt_type" (text "io.circe.Json.fromString" <> WL.parens (WL.dquotes (makeDiscriminator tn n))) :
                           with fts (\(M.Name fn, f'typ) -> field fn (text "io.circe.Encoder" <> WL.brackets (genTypeV1 f'typ) <> text ".apply" <> WL.parens (text fn)))
                       )
-          M.Record [] ->
-              case_expr
-                  (text tn)
-                  ( object
-                      [ field "adt_type" (text "io.circe.Json.fromString" <> WL.parens (WL.dquotes (makeDiscriminator "" tn)))
-                      ]
-                  )
           M.Record fts ->
             case_expr
               (text tn <> WL.tupled (with fts $ \(M.Name n, _) -> text n))
@@ -134,7 +126,7 @@ generateFromJsonV1 def@(M.Definition (M.Name tn) _ typ) =
                              ]
                       )
                 M.Record [] ->
-                  text "Right" <> WL.parens (text tn)
+                  text "Right" <> WL.parens (text tn <> WL.tupled [])
                 M.Record fts ->
                   for_yield
                     ( with fts $ \(M.Name f, ft) ->

--- a/machinator-scala/src/Machinator/Scala/Scheme/Types.hs
+++ b/machinator-scala/src/Machinator/Scala/Scheme/Types.hs
@@ -10,6 +10,7 @@ import           Data.Set (Set)
 import qualified Data.Text as T
 
 import           Machinator.Core
+import           Machinator.Core.Data.Definition
 import qualified Machinator.Core.Graph as MG
 import           Machinator.Scala.Data.Types
 import qualified Machinator.Scala.Scheme.Circe.Codegen as Codegen
@@ -21,35 +22,33 @@ import qualified System.FilePath.Posix as FilePath
 import           System.IO (FilePath)
 
 
-types :: ScalaTypesVersion -> [DefinitionFile] -> Either ScalaTypesError [(FilePath, Text)]
-types v ds =
+types :: ScalaTypesVersion -> Text -> [DefinitionFile] -> Either ScalaTypesError [(FilePath, Text)]
+types v pkg ds =
   case v of
     ScalaTypesV1 ->
-      typesV1 ds
+      typesV1 pkg ds
 
-typesV1 :: [DefinitionFile] -> Either ScalaTypesError [(FilePath, Text)]
-typesV1 dfs =
+typesV1 :: Text -> [DefinitionFile] -> Either ScalaTypesError [(FilePath, Text)]
+typesV1 pkg dfs =
   let DefinitionFileGraph fg = MG.buildFileGraph dfs
-      mg = M.mapKeys filePathToModuleName (fmap (M.keysSet . M.mapKeys filePathToModuleName) fg)
+      mg = M.mapKeys (filePathToModuleName pkg) (fmap (M.mapKeys (filePathToModuleName pkg)) fg)
   in for dfs $ \(DefinitionFile fp defs) ->
-       let mn = filePathToModuleName fp in
+       let mn = filePathToModuleName pkg fp in
        pure (genFileName mn, renderModule mn mg defs)
 
 -- -----------------------------------------------------------------------------
 
-renderModule :: ModuleName -> Map ModuleName (Set ModuleName) -> [Definition] -> Text
+renderModule :: ModuleName -> Map ModuleName (Map ModuleName (Set Name)) -> [Definition] -> Text
 renderModule mn@(ModuleName n) imports defs =
   T.unlines [
       T.unwords ["package", n]
-    , maybe mempty (T.unlines . fmap renderImport . toList) (M.lookup mn imports)
+    , maybe mempty (T.unlines . fmap renderImports . M.toList) (mfilter (not . null) $ M.lookup mn imports)
     , T.unlines . with defs $ \def ->
         Codegen.genTypesV1 def <> "\n" <> Codegen.generateToJsonV1Companion def
     ]
 
-renderImport :: ModuleName -> Text
-renderImport (ModuleName n) =
-  "import " <> n
-
+renderImports :: (ModuleName, Set Name) -> Text
+renderImports (ModuleName n, ns) = Codegen.genImportsV1 (Name n) ns
 
 -- -----------------------------------------------------------------------------
 
@@ -61,25 +60,25 @@ newtype ModuleName = ModuleName {
 -- | Derive a module name from the relative 'FilePath'.
 --
 -- @
--- λ> filePathToModuleName "./path_to/my/favourite_Template_place.hs"
--- ModuleName {unModuleName = "PathTo.My.FavouriteTemplatePlace"}
+-- λ> filePathToModuleName "example" "./path_to/my/favourite_Template_place.hs"
+-- ModuleName {unModuleName = "example.pathTo.my.favouriteTemplatePlace"}
 -- @
 --
 -- TODO V2 Accept an alternative function as a parameter.
-filePathToModuleName :: FilePath -> ModuleName
-filePathToModuleName =
-  ModuleName . T.pack . goUpper . FilePath.dropExtension
+filePathToModuleName :: Text -> FilePath -> ModuleName
+filePathToModuleName pkg =
+  ModuleName . (\m -> pkg <> "." <> m) . T.pack . goLower . FilePath.dropExtension
   where
-    goUpper [] = []
-    goUpper (x:xs)
-      | Char.isAlphaNum x = Char.toUpper x : go xs
-      | otherwise = goUpper xs
+    goLower [] = []
+    goLower (x:xs)
+      | Char.isAlphaNum x = Char.toLower x : go xs
+      | otherwise = goLower xs
     go [] = []
     go (x:xs)
-      | x == '/' = '.' : goUpper xs
+      | x == '/' = '.' : goLower xs
       | Char.isAlphaNum x = x : go xs
-      | otherwise = goUpper xs
+      | otherwise = goLower xs
 
 genFileName :: ModuleName -> FilePath
 genFileName (ModuleName n) =
-  T.unpack (T.replace "." "/" n) <> ".scala"
+  T.unpack (T.replace "." "/" n) <> "/generated.scala"


### PR DESCRIPTION
- Scala generator creates correct package names.
- Add Map to source language, very basic handling in generators for Python, Scala, Swagger.
- Define Circe KeyEncoder and KeyDecoder instances for newtypes of [some] base types.