### PR TITLE
Add flake nix with ghc8 + cabal dev shell for building.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1669833724,
+        "narHash": "sha256-/HEZNyGbnQecrgJnfE8d0WC5c1xuPSD2LUpB6YXlg4c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,38 @@
+{
+  description = "Machinator";
+
+  # Nixpkgs / NixOS version to use.
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/22.11";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      # System types to support.
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
+
+      # Helper function to generate an attrset '{ x86_64-linux = f "x86_64-linux"; ... }'.
+      forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
+
+      # Nixpkgs instantiated for supported system types.
+      nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
+    in
+    {
+      formatter = forAllSystems (system: nixpkgsFor.${system}.nixpkgs-fmt);
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in
+        {
+          default = pkgs.mkShell {
+            buildInputs = with pkgs; [
+              (haskell.packages.ghc810.ghcWithPackages
+                     (haskellPackages: with haskellPackages; [
+                       cabal-install
+                     ]))
+            ];
+          };
+        });
+    };
+}


### PR DESCRIPTION
Run `nix develop`  to get a shell with ghc8 then `cabal build` etc.

Couldn't get the project to package in nix quickly so just use a dev shell for now. We can create a nix build later so we can install the generator executables easily,